### PR TITLE
Fix buffer overflow in env variable name construction

### DIFF
--- a/src/httppars.c
+++ b/src/httppars.c
@@ -215,7 +215,7 @@ http_set_post_env(HTTPC *httpc, const UCHAR *name, const UCHAR *value)
 {
     char        newname[256];
 
-    sprintf(newname, "POST_%s", name);
+    snprintf(newname, sizeof(newname), "POST_%s", name);
 
     return http_set_env(httpc, newname, value);
 }

--- a/src/httpshen.c
+++ b/src/httpshen.c
@@ -11,7 +11,7 @@ httpshen(HTTPC *httpc, const UCHAR *name, const UCHAR *value)
 {
     char        newname[256];
     
-    sprintf(newname, "HTTP_%s", name);
+    snprintf(newname, sizeof(newname), "HTTP_%s", name);
 
     if (http_cmp(name, "Cookie")==0) {
 		return parse_cookies(httpc, value);
@@ -51,7 +51,7 @@ set_cookie(HTTPC *httpc, const UCHAR *name, const UCHAR *value)
 {
     char        newname[256];
     
-    sprintf(newname, "HTTP_Cookie-%s", name);
+    snprintf(newname, sizeof(newname), "HTTP_Cookie-%s", name);
 
     return http_set_env(httpc, newname, value);
 }

--- a/src/httpsqen.c
+++ b/src/httpsqen.c
@@ -8,7 +8,7 @@ httpsqen(HTTPC *httpc, const UCHAR *name, const UCHAR *value)
 {
     char        newname[256];
     
-    sprintf(newname, "QUERY_%s", name);
+    snprintf(newname, sizeof(newname), "QUERY_%s", name);
 
     return http_set_env(httpc, newname, value);
 }


### PR DESCRIPTION
## Summary

- Replace `sprintf()` with `snprintf()` in 4 locations across 3 files where user-controlled HTTP header, cookie, query, and POST parameter names are written into a fixed 256-byte stack buffer
- Prevents stack buffer overflow when parameter names exceed ~250 bytes

## Files changed

- `src/httpshen.c` — `HTTP_<name>` and `HTTP_Cookie-<name>` prefixes
- `src/httpsqen.c` — `QUERY_<name>` prefix
- `src/httppars.c` — `POST_<name>` prefix

## Test plan

- [x] Compiles clean with c2asm370 (no new warnings)
- [x] All 13 load modules linked on MVS (12x CC 0000, 1x CC 0004)
- [x] GET with query parameters — HTTP 200
- [x] POST with form data — HTTP 200
- [x] Custom HTTP header — HTTP 200
- [x] Cookie header — HTTP 200
- [x] 300-character parameter name — HTTP 200 (previously caused ABEND with original modules)

Fixes #2