### PR TITLE
Fix strcat overflow in query/POST string parsing

### DIFF
--- a/src/httppars.c
+++ b/src/httppars.c
@@ -46,7 +46,8 @@ httppars(HTTPC *httpc)
         if (http_set_env(httpc, "QUERY_STRING", p+1)) goto failed;
 
         /* parse the query string */
-        strcat(buf, "&");   /* append a final "&" to buffer */
+        if (strlen(buf) < CBUFSIZE - 2)
+            strcat(buf, "&");   /* append a final "&" to buffer */
         *p++ = 0;           /* "?" -> 0 byte */
         buf = p;            /* start of query variables */
         for (p=strchr(buf,'&'); p; buf=&buf[pos], p=strchr(buf,'&')) {
@@ -159,7 +160,8 @@ postdata:
     if (http_set_env(httpc, "POST_STRING", buf)) goto failed;
 
     /* parse string into "POST_..." variables */
-    strcat(buf, "&");   /* append a final "&" to buffer */
+    if (strlen(buf) < CBUFSIZE - 2)
+        strcat(buf, "&");   /* append a final "&" to buffer */
     for (p=strchr(buf,'&'); p; buf=&buf[pos], p=strchr(buf,'&')) {
         *p++ = 0;
         pos = (int)(p - buf);


### PR DESCRIPTION
## Summary

- Add bounds check before `strcat(buf, "&")` in both query string and POST body parsers in `httppars.c`
- Prevents off-by-one write past the end of the CBUFSIZE (4008 byte) buffer

## Files changed

- `src/httppars.c` — lines 49 and 162: guard `strcat()` with `strlen(buf) < CBUFSIZE - 2`

## Test plan

- [x] Compiles clean with c2asm370
- [x] All 13 load modules linked on MVS (12x CC 0000, 1x CC 0004)
- [x] Normal GET with query parameters — HTTP 200
- [x] Normal POST to /login — HTTP 200
- [x] POST with 4007-byte body (CBUFSIZE-1 boundary) — HTTP 200, server stable
- [x] JES2 query after fix — HTTP 200

Fixes #4