### PR TITLE
Fix path traversal in http_open

### DIFF
--- a/src/httpopen.c
+++ b/src/httpopen.c
@@ -20,6 +20,9 @@ http_open(HTTPC *httpc, const UCHAR *path, const HTTPM *mime)
 
     if (!path) goto quit;
 
+    /* reject path traversal attempts */
+    if (strstr(path, "..")) goto quit;
+
     len = strlen(path);
     if (len >= sizeof(buf)) len = sizeof(buf)-1;
 


### PR DESCRIPTION
## Summary

- Reject any path containing `..` in `http_open()` before opening files
- Protects all callers: GET requests, SSI includes, POST/PUT handlers
- Returns NULL (file not found) for traversal attempts

## Test plan

- [x] Normal GET `/` returns 200
- [x] Path traversal `/../../../etc/passwd` returns 404
- [x] URL-encoded traversal `..%2F..%2F` returns 404
- [x] mvsMF API still works (200)
- [x] JES status still works (200)
- [x] Query strings still work (200)

Fixes #5