### PR TITLE
feat: configurable document root for UFS

### DIFF
--- a/include/httpd.h
+++ b/include/httpd.h
@@ -150,7 +150,8 @@ struct httpd {
 #define HTTPD_CGICTX_MVSMF  0       /* ... MVSMF CGI context index  */
 #define HTTPD_CGICTX_MIN    0       /* ... minimum number of cgictx */
 #define HTTPD_CGICTX_MAX    255     /* ... maximum number of cgictx */
-};                                  /* A0 (160 bytes)               */
+    char        docroot[128];       /* A0 UFS document root prefix  */
+};                                  /* 120                          */
 
 /* Telemetry */
 struct httpt {

--- a/src/httpconf.c
+++ b/src/httpconf.c
@@ -547,6 +547,24 @@ process_httpd_ufs(lua_State *L, HTTPD *httpd)
 
     if (crt) crt->crtufs = ufs;
 
+    /* Read document root prefix (optional) */
+    lua_getfield(L, -1, "docroot");
+    {
+        const char *dr = lua_tostring(L, -1);
+        if (dr && dr[0] == '/') {
+            int drlen = strlen(dr);
+            /* strip trailing slash */
+            if (drlen > 1 && dr[drlen - 1] == '/')
+                drlen--;
+            if (drlen >= (int)sizeof(httpd->docroot))
+                drlen = (int)sizeof(httpd->docroot) - 1;
+            memcpy(httpd->docroot, dr, drlen);
+            httpd->docroot[drlen] = '\0';
+            wtof("HTTPD047I Document root: %s", httpd->docroot);
+        }
+    }
+    lua_pop(L, 1);
+
 quit:
 	return rc;
 }
@@ -1094,6 +1112,9 @@ setHttpdDefaults(lua_State *L)
 	
 	lua_pushstring(L, "1");
 	lua_setfield(L,-2,"ufs");		// table.ufs="1"
+
+	lua_pushstring(L, "");
+	lua_setfield(L,-2,"docroot");	// table.docroot=""
 	
 	lua_pushstring(L, "HTTPD.CGILUA");
 	lua_setfield(L,-2,"cgilua_dataset");	// table.cgilua_dataset="HTTPD.CGILUA"

--- a/src/httpopen.c
+++ b/src/httpopen.c
@@ -98,11 +98,16 @@ http_open(HTTPC *httpc, const UCHAR *path, const HTTPM *mime)
 
 
     if (httpc->ufs) {
-        httpc->ufp = ufs_fopen(httpc->ufs, buf, mode);
-		// wtof("%s: ufs_fopen(%p, \"%s\", \"%s\") httpc->ufp=%p", 
-		// 	__func__, httpc->ufs, buf, mode, httpc->ufp);
+        UCHAR ufspath[256];
+        const char *dr = httpc->httpd->docroot;
+        if (dr[0] && http_cmpn(buf, "/DD:", 4) != 0) {
+            /* prepend document root to UFS path */
+            snprintf((char *)ufspath, sizeof(ufspath), "%s%s", dr, buf);
+            httpc->ufp = ufs_fopen(httpc->ufs, ufspath, mode);
+        } else {
+            httpc->ufp = ufs_fopen(httpc->ufs, buf, mode);
+        }
         if (httpc->ufp) {
-            /* wtof("%s opened \"%s\" UFS", __func__, buf); */
             goto quit;  /* success, return NULL to caller */
         }
     }


### PR DESCRIPTION
## Summary
- Add `httpd.docroot` Lua config option to prefix UFS file paths in HTTP requests
- Allows mounting a dedicated UFS disk via UFSD parmlib and pointing HTTPD at it
- `/DD:` paths bypass the docroot prefix (PDS-based static content unaffected)

## Example
```lua
httpd.docroot = "/www"
```

With UFSD parmlib:
```
MOUNT DSN(HTTPD.WEBROOT) PATH(/www) MODE(RO)
```

URL `/index.html` resolves to UFS path `/www/index.html`.

## Files changed
- `include/httpd.h` — `docroot[128]` field in HTTPD struct
- `src/httpconf.c` — read `httpd.docroot` from Lua config
- `src/httpopen.c` — prepend docroot to UFS paths in `http_open`

## Test plan
- [x] Build RC=0 (full rebuild after struct change)
- [x] Link RC=0
- [x] HTTPD starts and serves files with docroot set