### PR TITLE
Fix ufs_sys_term() calls for new libufs signature

### DIFF
--- a/src/httpconf.c
+++ b/src/httpconf.c
@@ -538,7 +538,7 @@ process_httpd_ufs(lua_State *L, HTTPD *httpd)
     httpd->ufs = ufs = ufsnew();
     if (!ufs) {
         wtof("HTTPD044W Unable to open UFSD session");
-        ufs_sys_term();
+        ufs_sys_term(&httpd->ufssys);
         httpd->ufssys = NULL;
         goto quit;
     }

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -324,7 +324,7 @@ terminate(void)
 
     if (httpd->ufssys) {
         wtof("HTTPD047I Terminating File System");
-        ufs_sys_term();
+        ufs_sys_term(&httpd->ufssys);
         httpd->ufssys = NULL;
     }
 


### PR DESCRIPTION
## Summary
- Adapt both `ufs_sys_term()` call sites (`httpconf.c:541`, `httpd.c:327`) to pass `&httpd->ufssys` matching the updated libufs API

## Test plan
- [ ] Verify build completes with RC=0