### PR TITLE
Remove DD-based docroot, UFS-only static file serving

### DIFF
--- a/src/httpfile.c
+++ b/src/httpfile.c
@@ -462,47 +462,7 @@ quit:
 
 }
 
-/* ddname() convert "/index.html" -> "/DD:html(index)" */
-static UCHAR *
-ddname(const UCHAR *in, UCHAR *out, int size)
-{
-    UCHAR   *ext    = strchr(in,'.');
-    UCHAR   *mem    = strchr(in,'/');
-    int     extlen  = ext ? strlen(ext+1) : 0;
-    int     memlen  = (mem && ext) ? (int)(ext-mem) - 1 : 0;
-    int     pos     = 0;
-    int     len;
-
-    /* we need space for "/DD:_ddname_(_member_)" */
-    if (size < sizeof("/DD:_ddname_(_member_)")) goto quit;
-
-    if (extlen < 0 OR memlen < 0 OR strchr(in, ':')) {
-        /* doesn't look like a normal "file.ext" name */
-        out = NULL;
-        goto quit;
-    }
-
-    if (extlen > 8) extlen = 8; /* limit ddname to 8 characters */
-    if (memlen > 8) memlen = 8; /* limit member name to 8 characters */
-
-    strcpy(out, "/DD:");
-    pos += 4;
-
-    for(ext++;(*ext) && (extlen > 0); extlen--) {
-        out[pos++]=*ext++;
-    }
-    out[pos++] = '(';
-    for(mem++;(*mem) && (*mem!='.') && (memlen > 0); memlen--) {
-        out[pos++]=*mem++;
-    }
-    out[pos++] = ')';
-    out[pos] = 0;
-
-quit:
-    return out;
-}
-
-static int 
+static int
 ssi_include(HTTPC *httpc, char *next)
 {
 	int			isfile		= 0;
@@ -516,7 +476,6 @@ ssi_include(HTTPC *httpc, char *next)
     UCHAR   	subtype		= httpc->subtype;
     UCHAR		substate	= httpc->substate;
     UCHAR		ssi			= httpc->ssi;
-    char		buf[40];
     char		uri[UFS_PATH_MAX];
 
 	// wtof("%s: enter next=\"%s\"", __func__, next);
@@ -555,40 +514,17 @@ ssi_include(HTTPC *httpc, char *next)
 	strncpy(uri, path, sizeof(uri));
 	uri[sizeof(uri)-1] = 0;
 
-    if (httpc->ufs) {
-        /* try to open path asis */
-        mime = http_mime(path);
-        if (!mime->binary) {
-			httpc->fp = http_open(httpc, path, mime);
-			if (httpc->fp || httpc->ufp) goto okay;   /* file was opened */
-		}
+    mime = http_mime(path);
+    if (mime->binary) {
+        ssi_printf(httpc, "<!-- Oops: we can't include a binary file \"%s\" -->\n", uri);
+        goto quit;
     }
 
-	/* now we'll try to convert the path to a "/DD:EXT(MEMBER)" */
-    if (http_cmpn(path,"/DD:",4)!=0 &&
-        strchr(path,'.') && strlen(path) < 19) {
-
-        /* convert the path to a "/DD:ddname(member)" */
-        if (ddname(path, buf, sizeof(buf))) {
-            path = buf;
-
-			mime = http_mime(path);
-			if (!mime->binary) {
-				/* open the file */
-				httpc->fp = http_open(httpc, path, mime);
-			}
-		}
-	}
-
-	if (!httpc->fp && !httpc->ufp) {
-        if (mime->binary) {
-			ssi_printf(httpc, "<!-- Oops: we can't include a binary file \"%s\" -->\n", uri);
-			goto quit;
-		}
-		/* open failed for path name */
-		ssi_printf(httpc, "<!-- Oops: we didn't find \"%s\" -->\n", uri);
-		goto quit;
-	}
+    httpc->fp = http_open(httpc, path, mime);
+    if (!httpc->fp && !httpc->ufp) {
+        ssi_printf(httpc, "<!-- Oops: we didn't find \"%s\" -->\n", uri);
+        goto quit;
+    }
 
 okay:
 	// ssi_printf(httpc, "\n");

--- a/src/httpget.c
+++ b/src/httpget.c
@@ -11,46 +11,6 @@ enum ctype {
     CTYPE_TEXT
 };
 
-/* ddname() convert "/index.html" -> "/DD:html(index)" */
-static UCHAR *
-ddname(const UCHAR *in, UCHAR *out, int size)
-{
-    UCHAR   *ext    = strchr(in,'.');
-    UCHAR   *mem    = strchr(in,'/');
-    int     extlen  = ext ? strlen(ext+1) : 0;
-    int     memlen  = (mem && ext) ? (int)(ext-mem) - 1 : 0;
-    int     pos     = 0;
-    int     len;
-
-    /* we need space for "/DD:_ddname_(_member_)" */
-    if (size < sizeof("/DD:_ddname_(_member_)")) goto quit;
-
-    if (extlen < 0 OR memlen < 0 OR strchr(in, ':')) {
-        /* doesn't look like a normal "file.ext" name */
-        out = NULL;
-        goto quit;
-    }
-
-    if (extlen > 8) extlen = 8; /* limit ddname to 8 characters */
-    if (memlen > 8) memlen = 8; /* limit member name to 8 characters */
-
-    strcpy(out, "/DD:");
-    pos += 4;
-
-    for(ext++;(*ext) && (extlen > 0); extlen--) {
-        out[pos++]=*ext++;
-    }
-    out[pos++] = '(';
-    for(mem++;(*mem) && (*mem!='.') && (memlen > 0); memlen--) {
-        out[pos++]=*mem++;
-    }
-    out[pos++] = ')';
-    out[pos] = 0;
-
-quit:
-    return out;
-}
-
 extern int
 httpget(HTTPC *httpc)
 {
@@ -76,71 +36,30 @@ httpget(HTTPC *httpc)
         __asm__("DC\tH'0'");
     }
 
-    if (http_get_ufs(httpc)) {
-        /* try to open path asis */
-        mime = http_mime(path);
-        fp = http_open(httpc, path, mime);
-		// wtof("%s: 1 http_open(%p, \"%s\", %p) fp=%p, httpc->ufp=%p", 
-		// 	__func__, httpc, path, mime, fp, httpc->ufp);
-        if (fp || httpc->ufp) goto okay;   /* file was opened */
-        
-        /* If the path is for a directory then we need to see if a 
-         * "index.html" exist in this directory and open it.
-         */
-        len = strlen(path);
-        if (path[len-1]=='/') {
-			memcpy(buf, path, len);
-			strcpy(&buf[len], "index.html");
-
-			mime = http_mime(buf);
-			fp = http_open(httpc, buf, mime);
-        
-			if (fp || httpc->ufp) goto okay;   /* file was opened */
-		}
-    }
-
-    if (http_cmpn(path,"/DD:",4)!=0 &&
-        strchr(path,'.') && strlen(path) < 19) {
-
-        /* convert the path to a "/DD:ddname(member)" */
-        if (ddname(path, buf, sizeof(buf))) {
-            path = buf;
-            http_dbgf("ddname:\"%s\"\n", path);
-        }
-    }
+    /* try to open path from UFS */
     mime = http_mime(path);
-
-    /* try to open the requested document */
     fp = http_open(httpc, path, mime);
-	// wtof("%s: 2 http_open(%p, \"%s\", %p) fp=%p, httpc->ufp=%p", 
-	// 	__func__, httpc, path, mime, fp, httpc->ufp);
-    if (!fp && !httpc->ufp && http_cmp(path,"/")==0) {
-        /* try to open default documents */
-        path = "/index.html";
-        mime = http_mime(path);
-        fp = http_open(httpc, path, mime);
-        if (!fp && !httpc->ufp) {
-            path = "/default.html";
-            mime = http_mime(path);
-            fp = http_open(httpc, path, mime);
-        }
-        if (!fp && !httpc->ufp) {
-            path = "/DD:HTML(INDEX)";
-            mime = http_mime(path);
-            fp = http_open(httpc, path, mime);
-        }
-        if (!fp && !httpc->ufp) {
-            /* try another one */
-            path = "/DD:HTML(DEFAULT)";
-            fp = http_open(httpc, path, mime);
-        }
+    if (fp || httpc->ufp) goto okay;
+
+    /* If the path is for a directory, try index.html / default.html */
+    len = strlen(path);
+    if (path[len-1]=='/') {
+        memcpy(buf, path, len);
+        strcpy(&buf[len], "index.html");
+        mime = http_mime(buf);
+        fp = http_open(httpc, buf, mime);
+        if (fp || httpc->ufp) goto okay;
+
+        strcpy(&buf[len], "default.html");
+        mime = http_mime(buf);
+        fp = http_open(httpc, buf, mime);
+        if (fp || httpc->ufp) goto okay;
     }
 
-    if (!fp && !httpc->ufp) {
-        rc = http_resp_not_found(httpc, path);
-        httpc->state = CSTATE_DONE;
-        goto quit;
-    }
+    /* file not found */
+    rc = http_resp_not_found(httpc, path);
+    httpc->state = CSTATE_DONE;
+    goto quit;
 
 okay:
     httpc->fp = fp;
@@ -153,9 +72,8 @@ okay:
     if (rc) goto die;
 #if 1
 	/* don't allow the browser to cache our html documents */
-	if (strstr(mime->type, "html") || 
-		__patmat(path, "*.html") || 
-		__patmat(path, "/DD:HTML(*)")) {
+	if (strstr(mime->type, "html") ||
+		__patmat(path, "*.html")) {
 		rc = http_printf(httpc, "Cache-Control: no-store\r\n");
 		if (rc) goto die;
 	}

--- a/src/httpopen.c
+++ b/src/httpopen.c
@@ -7,16 +7,9 @@
 FILE *
 http_open(HTTPC *httpc, const UCHAR *path, const HTTPM *mime)
 {
-    FILE    *fp     = NULL;
     UCHAR   *mode;
-    UCHAR   *p;
     int     len;
-    int     lock;
-    UCHAR   ddname[12] = "";
-    UCHAR   member[12] = "";
     UCHAR   buf[256];
-
-	// wtof("%s: enter path=\"%s\"", __func__, path);
 
     if (!path) goto quit;
 
@@ -29,50 +22,6 @@ http_open(HTTPC *httpc, const UCHAR *path, const HTTPM *mime)
     memcpy(buf, path, len);
     buf[len]=0;
 
-    /* wtof("%s buf=\"%s\"", __func__, buf); */
-
-    if (http_cmpn(buf, "/DD:", 4)==0) {
-        /* open by DD name */
-        strcpy(buf, buf+1); /* strip leading '/' */
-
-        /* Ideally we would expect the path to be "/DD:EXT(MEMBER)"
-        ** but we'd also like to handle "/DD:MEMBER.EXT" and convert
-        ** that internally to "/DD:EXT(MEMBER)".
-        **
-        ** The EXT part of the name will be used to lookup the MIME
-        ** info and would also be used as the DDNAME to open.
-        */
-
-        p = strchr(buf, '(');
-        if (!p) {
-            /* We likely have "DD:MEMBER.EXT" */
-            p = strrchr(buf, '.'); /* find the extension */
-            if (p) {
-                /* We have "DD:MEMBER.EXT"
-                ** Use the EXT as the DDNAME
-                */
-                p++;
-                len = strlen(p);
-                if (len>=sizeof(ddname)) len = sizeof(ddname)-1;
-                memcpy(ddname, p, len);
-                ddname[len] = 0;
-            }
-            else {
-                /* We don't want to allow "DD:MEMBER"
-                ** They should use "DD:MEMBER.EXT"
-                */
-                goto quit;
-            }
-
-            len = strlen(&buf[3]);
-            if (len>=sizeof(member)) len = sizeof(member)-1;
-            memcpy(member, &buf[3], len);
-            member[len] = 0;
-            /* convert to "DD:DDNAME(MEMBER)" */
-            sprintf(buf, "DD:%s(%s)", ddname, member);
-        }
-    }
-
     if (!mime) mime = (const HTTPM *) http_mime(buf);
 
     if (mime) {
@@ -82,42 +31,30 @@ http_open(HTTPC *httpc, const UCHAR *path, const HTTPM *mime)
 		else {
 			mode = "r";
 		}
-		
+
 		if (http_cmp(mime->type, "text/html")==0 ||
 			http_cmp(mime->type, "text/x-server-parsed-html")==0) {
-			/* enable Server Side Include processing of this file */
 			httpc->ssi = 1;
-			// wtof("%s: enabling SSI processing for \"%s\" as \"%s\"", __func__, buf, mime->type);
 		}
 		else {
-			/* disable Server Side Processing of this file */
 			httpc->ssi = 0;
-			// wtof("%s: disabling SSI processing for \"%s\" as \"%s\"", __func__, buf, mime->type);
 		}
 	}
-
 
     {
         UFS *ufs = http_get_ufs(httpc);
         if (ufs) {
             UCHAR ufspath[256];
             const char *dr = httpc->httpd->docroot;
-            if (dr[0] && http_cmpn(buf, "/DD:", 4) != 0) {
-                /* prepend document root to UFS path */
+            if (dr[0]) {
                 snprintf((char *)ufspath, sizeof(ufspath), "%s%s", dr, buf);
                 httpc->ufp = ufs_fopen(ufs, ufspath, mode);
             } else {
                 httpc->ufp = ufs_fopen(ufs, buf, mode);
             }
-            if (httpc->ufp) {
-                goto quit;  /* success, return NULL to caller */
-            }
         }
     }
 
-    fp = fopen(buf, mode);
-
 quit:
-	// wtof("%s: exit fp=%p", __func__, fp);
-    return fp;
+    return NULL;
 }


### PR DESCRIPTION
## Summary
- Remove `ddname()` functions and all `/DD:` path logic from `httpget.c`, `httpopen.c`, `httpfile.c`
- Static files served exclusively from UFS via UFSD
- Default document fallback simplified to `/index.html` and `/default.html`
- SSI includes now UFS-only (no DD conversion)
- Cross-compilation verified: 113 modules RC=0

**-244 lines, +35 lines** — net removal of ~210 lines of DD path handling code.

## Test plan
- [ ] Full `make build link` on MVS when host is available
- [ ] Verify static file serving from UFS docroot
- [ ] Verify 404 for non-existent files
- [ ] Verify SSI includes work from UFS

Fixes #48