### PR TITLE
feat: automatic chunked transfer encoding for CGI responses

### DIFF
--- a/src/httpget.c
+++ b/src/httpget.c
@@ -108,25 +108,10 @@ okay:
         }
     }
 
-    /* chunked transfer encoding only for HTTP/1.1 clients */
-    {
-        int use_chunked = 0;
-        if (!httpc->content_length_set) {
-            UCHAR *ver = http_get_env(httpc, "REQUEST_VERSION");
-            if (ver && http_cmp(ver, "HTTP/1.1") == 0) {
-                rc = http_printf(httpc, "Transfer-Encoding: chunked\r\n");
-                if (rc) goto die;
-                use_chunked = 1;
-            }
-            /* HTTP/1.0: no chunked, body delimited by Connection: close */
-        }
-
-        rc = http_printf(httpc, "\r\n");
-        if (rc) goto die;
-
-        /* enable chunk framing AFTER header-ending CRLF is sent */
-        httpc->chunked = use_chunked;
-    }
+    /* end of headers — httpprtv auto-injects Transfer-Encoding: chunked
+       for HTTP/1.1 clients when Content-Length was not set */
+    rc = http_printf(httpc, "\r\n");
+    if (rc) goto die;
 
     /* indicate type of document being sent */
     if (mime->binary) {

--- a/src/httpprtv.c
+++ b/src/httpprtv.c
@@ -18,28 +18,50 @@ httpprtv(HTTPC *httpc, const char *fmt, va_list args)
         rc = -1;
     }
     else {
-#if 0   /* debugging */
-        wtof("httpprtv:");
-        for(pos=0; pos < len; pos+=80) {
-            int j = len - pos;
-            if (j > 80) j = 80;
-            wtof("%-*.*s", j, j, &buf[pos]);
+        /* auto-detect Content-Length header from any caller */
+        if (len >= 15 && http_cmpn(buf, "Content-Length:", 15) == 0)
+            httpc->content_length_set = 1;
+
+        /* auto-detect header terminator (blank line = "\r\n" only)
+           and inject Transfer-Encoding: chunked for HTTP/1.1 if needed */
+        if (len == 2 && buf[0] == '\r' && buf[1] == '\n'
+            && httpc->resp > 0 && !httpc->rdw) {
+            httpc->rdw = 1; /* headers ended — don't re-trigger */
+
+            if (!httpc->content_length_set && !httpc->chunked) {
+                UCHAR *ver = http_get_env(httpc, "REQUEST_VERSION");
+                if (ver && http_cmp(ver, "HTTP/1.1") == 0) {
+                    /* inject Transfer-Encoding header before blank line */
+                    UCHAR te[] = "Transfer-Encoding: chunked\r\n";
+                    int te_len = sizeof(te) - 1;
+                    http_etoa(te, te_len);
+                    for (pos = 0; pos < te_len; pos += rc) {
+                        rc = http_send(httpc, &te[pos], te_len - pos);
+                        if (rc < 0) goto quit;
+                    }
+                    /* send the blank line (header terminator) */
+                    http_etoa(buf, len);
+                    for (pos = 0; pos < len; pos += rc) {
+                        rc = http_send(httpc, &buf[pos], len - pos);
+                        if (rc < 0) goto quit;
+                    }
+                    /* enable chunk framing for subsequent body data */
+                    httpc->chunked = 1;
+                    rc = 0;
+                    goto quit;
+                }
+            }
         }
-#endif
+
+        /* normal path: convert EBCDIC → ASCII and send */
         http_etoa(buf, len);
         for(pos=0; pos < len; pos+=rc) {
             rc = http_send(httpc, &buf[pos], len-pos);
-#if 0
-            wtof("http_send() rc=%d", rc);
-#endif
             if (rc<0) goto quit;
         }
         rc = 0;
     }
 
 quit:
-#if 0
-    wtof("httpprtv() rc=%d", rc);
-#endif
     return rc;
 }

--- a/src/httprese.c
+++ b/src/httprese.c
@@ -33,6 +33,7 @@ httprese(HTTPC *httpc)
     httpc->substate = 0;
     httpc->chunked = 0;
     httpc->content_length_set = 0;
+    httpc->rdw = 0;
     memset(httpc->buf, 0, CBUFSIZE);
 
     /* clear ACEE on UFS session between requests */


### PR DESCRIPTION
## Summary

- Auto-inject `Transfer-Encoding: chunked` in `httpprtv.c` when the header-ending blank line is sent without Content-Length or chunked for HTTP/1.1 clients
- Auto-detect `Content-Length:` headers from any caller (including external CGI modules like mvsMF)
- Remove explicit chunked logic from `httpget.c` — now handled centrally
- Reset `rdw` flag in `httprese.c` for keep-alive request cycling

## How it works

`httpprtv.c` is the central printf path all code uses (HTTPD core + CGI modules via HTTPX vector). When it sees:
1. A `Content-Length:` header → sets `content_length_set` flag
2. The header-ending blank line (`"\r\n"`, 2 bytes) → checks if chunked fallback is needed
3. If HTTP/1.1 and no Content-Length/chunked → injects `Transfer-Encoding: chunked` header, enables chunk framing

## Test plan

- [ ] Build on MVS (`make build && make link`)
- [ ] CGI pages (HTTPDSRV, HTTPDM, HTTPDMTT) show `Transfer-Encoding: chunked`
- [ ] Browser renders CGI pages immediately, no timeout waiting
- [ ] mvsMF API responses still use `Content-Length` (not chunked)
- [ ] Static files with known size still use `Content-Length`
- [ ] Static files without known size (SSI) use chunked
- [ ] HTTP/1.0 clients receive no chunked encoding
- [ ] Keep-alive works correctly across multiple requests

Fixes #58