### PR TITLE
fix: resolve open bugs #7, #8, #9, #11

### DIFF
--- a/src/httpd.c
+++ b/src/httpd.c
@@ -342,6 +342,12 @@ build_fd_set(fd_set *read, fd_set *write, fd_set *excp)
         memset(excp, 0, sizeof(fd_set));
     }
 
+    /* NOTE: httpd->httpc[] is read here without lock.
+     * This is safe because build_fd_set() runs in the same
+     * socket_thread as array_add(). array_del() in httpclos
+     * runs in worker threads but sets entries to NULL before
+     * removal, and we check for NULL below.
+     */
     for(n=0; n < count; n++) {
         httpc = httpd->httpc[n];
         if (!httpc) continue;           /* no client handle? */
@@ -550,7 +556,9 @@ socket_thread(void *arg1, void *arg2)
             }
             else {
                 /* add new client to array of clients */
+                lock(httpd, 0);
                 array_add(&httpd->httpc, httpc);
+                unlock(httpd, 0);
             }
         } /* if (FD_ISSET(httpd->listen, &read)) */
 

--- a/src/httpdbug.c
+++ b/src/httpdbug.c
@@ -20,25 +20,28 @@ http_debug(HTTPC *httpc, const char *options)
 	
 	http_printf(httpc, "<!--\n");
 
-	for(opt = strtok(opts, ","), next = strtok(NULL,""); opt; 
-		opt = next ? strtok(next, ",") : NULL, next = strtok(NULL,"")) {
+	for (opt = opts; opt && *opt; ) {
+		/* skip leading commas */
+		while (*opt == ',') opt++;
+		if (!*opt) break;
+
+		/* find end of this option */
+		char *end = strchr(opt, ',');
+		if (end) *end++ = 0;
 
 		len = strlen(opt);
 
 		if (http_cmpn(opt, "cgi", len)==0) {
 			dump_cgi(httpd, httpc);
-			continue;
 		}
-	
-		if (http_cmpn(opt, "help", len)==0 || http_cmp(opt, "?")==0) {
+		else if (http_cmpn(opt, "help", len)==0 || http_cmp(opt, "?")==0) {
 			dump_help(httpd, httpc);
-			continue;
 		}
-		if (http_cmpn(opt, "vars", len)==0) {
+		else if (http_cmpn(opt, "vars", len)==0) {
 			dump_vars(httpd, httpc);
-			continue;
 		}
 
+		opt = end;
 	}
 
 	http_printf(httpc, "-->\n");

--- a/src/httpfile.c
+++ b/src/httpfile.c
@@ -283,11 +283,13 @@ ssi_process(HTTPC *httpc, char *ssi)
 	while (isspace(*p)) p++;	/* skip any white space */
 	if (!*p) goto invalid;
 
-	p = strtok(p, " ");			/* isolate the ssi request */
-	if (!p) goto invalid;
-	
-	next = strtok(NULL,"");		/* remember whatever follows the request */
-	if (!next) goto invalid;
+	/* isolate the ssi request (split at first space) */
+	next = p;
+	while (*next && *next != ' ') next++;
+	if (!*next) goto invalid;
+	*next++ = 0;
+	while (isspace(*next)) next++;
+	if (!*next) goto invalid;
 
 	if (http_cmp(p, "echo")==0) {
 		/* next *should* point to whatever follows "<!--#echo " */
@@ -381,8 +383,12 @@ ssi_echo(HTTPC *httpc, char *next)
 
 	while(isspace(*p)) p++;
 	
-	var = strtok(p, "\"\'");
-	if (!var) goto quit;
+	/* extract quoted value — skip opening quote */
+	if (*p == '"' || *p == '\'') p++;
+	var = p;
+	while (*p && *p != '"' && *p != '\'') p++;
+	*p = 0;
+	if (!*var) goto quit;
 	
 	while(isspace(*var)) var++;
 
@@ -505,8 +511,12 @@ ssi_include(HTTPC *httpc, char *next)
 
 	while(isspace(*p)) p++;
 	
-	path = strtok(p, "\"\'");
-	if (!path) goto bad;
+	/* extract quoted path — skip opening quote */
+	if (*p == '"' || *p == '\'') p++;
+	path = p;
+	while (*p && *p != '"' && *p != '\'') p++;
+	*p = 0;
+	if (!*path) goto bad;
 	
 	while(isspace(*path)) path++;
 

--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -492,11 +492,14 @@ do_print(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid)
         buf = calloc(1, strlen(p)+1);
         if (buf) {
             strcpy(buf, p);
-            for(p=strtok(buf, " ,"); p; p = strtok(NULL, " ,")) {
+            for (p = buf; p && *p; ) {
+                while (*p == ' ' || *p == ',') p++;
+                if (!*p) break;
                 n = (unsigned) atoi(p);
                 if (n) {
                     array_add(&dsid, (void*)n);
                 }
+                while (*p && *p != ' ' && *p != ',') p++;
             }
         }
     }
@@ -770,8 +773,13 @@ do_cancel_ex(HTTPD *httpd, HTTPC *httpc, const char *verb, int purge, int all)
     buf = calloc(1, strlen(jobid)+1);
     if (buf) {
         strcpy(buf, jobid);
-        for(p=strtok(buf, ","); p; p = strtok(NULL, ",")) {
+        for (p = buf; p && *p; ) {
+            while (*p == ',') p++;
+            if (!*p) break;
+            UCHAR *end = strchr(p, ',');
+            if (end) *end++ = 0;
             array_add(&jobids, p);
+            p = end;
         }
     }
 

--- a/src/httpnenv.c
+++ b/src/httpnenv.c
@@ -6,9 +6,14 @@
 extern HTTPV *
 httpnenv(const UCHAR *name, const UCHAR *value)
 {
-    int         namelen = strlen(name);
-    int         vallen  = value ? strlen(value) : 0;
-    HTTPV       *v      = calloc(1, sizeof(HTTPV)+namelen+vallen);
+    size_t      namelen = strlen(name);
+    size_t      vallen  = value ? strlen(value) : 0;
+    size_t      total   = sizeof(HTTPV) + namelen + vallen + 2;
+    HTTPV       *v;
+
+    if (namelen + vallen > 8192) return NULL; /* sanity limit */
+
+    v = calloc(1, total);
 
     if (v) {
         strcpy(v->eye, HTTPV_EYE);

--- a/src/httppars.c
+++ b/src/httppars.c
@@ -89,7 +89,7 @@ httppars(HTTPC *httpc)
 
     if (http_set_env(httpc, "SERVER_PROTOCOL", "HTTP/1.1")) goto failed;
     
-    sprintf(tmp, "HTTPD/%s", httpc->httpd->version);
+    snprintf(tmp, sizeof(tmp), "HTTPD/%s", httpc->httpd->version);
     if (http_set_env(httpc, "SERVER_SOFTWARE", tmp)) goto failed;
 
     /* select next state based on request method */

--- a/src/httpshen.c
+++ b/src/httpshen.c
@@ -32,7 +32,16 @@ parse_cookies(HTTPC *httpc, const UCHAR *in)
 		return ENOMEM;
 	}
 	
-	for(name=strtok(buf, "; "); name; name=strtok(NULL, "; ")) {
+	for (name = buf; name && *name; ) {
+		/* skip leading delimiters */
+		while (*name == ';' || *name == ' ') name++;
+		if (!*name) break;
+
+		/* find end of this token */
+		UCHAR *end = name;
+		while (*end && *end != ';' && *end != ' ') end++;
+		if (*end) *end++ = 0;
+
 		value = strchr(name, '=');
 		if (value) {
 			*value++ = 0;
@@ -41,6 +50,7 @@ parse_cookies(HTTPC *httpc, const UCHAR *in)
 			value = "";
 		}
 		set_cookie(httpc, name, value);
+		name = end;
 	}
 	
 	free(buf);

--- a/src/httpshen.c
+++ b/src/httpshen.c
@@ -44,6 +44,7 @@ parse_cookies(HTTPC *httpc, const UCHAR *in)
 	}
 	
 	free(buf);
+	return 0;
 }
 
 static int


### PR DESCRIPTION
## Summary

Four open bugs fixed in separate commits:

1. **#8 — Missing return in parse_cookies()** (httpshen.c)
   Added `return 0;` — was undefined behavior

2. **#7 — Integer overflow in env allocation** (httpnenv.c)
   Use `size_t` instead of `int`, add +2 for null terminators, reject combined lengths > 8192

3. **#11 — strtok thread safety + minor fixes** (5 files)
   Replace all `strtok()` with manual pointer-based tokenizers in httpshen.c, httpdbug.c, httpjes2.c, httpfile.c. Use `snprintf` in httppars.c

4. **#9 — Race condition in client array** (httpd.c)
   Add `lock()`/`unlock()` around `array_add(&httpd->httpc)` to match the existing locking in `httpclos.c`

## Test plan

- [ ] Build on MVS (`make build && make link`)
- [ ] Cookie parsing still works (httpshen.c)
- [ ] Debug query variable works (`?debug=cgi,vars`)
- [ ] JES2 spool browser multi-DSID and multi-jobid work
- [ ] SSI includes work (httpfile.c)
- [ ] Server stable under concurrent load (race condition fix)

Fixes #7, Fixes #8, Fixes #9, Fixes #11