### PR TITLE
fix: do not apply chunked transfer-encoding to body-less responses (204/304/1xx)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,10 @@ In HTTPD 4.0.0, CGI registration moves from Lua defaults to Parmlib-only. No CGI
 ### HTTP/1.1 Design (to be implemented)
 
 **Response body framing — decision logic:**
+0. If the status is body-less (`1xx`, `204`, `304`) → never set Content-Length or
+   Transfer-Encoding and never emit a body (RFC 7230 §3.3.1). The chunked fallback in
+   `httpprtv.c` skips these; otherwise the `0\r\n\r\n` trailer from `httpdone.c` is an
+   illegal body that strict parsers (llhttp/Node) reject.
 1. If handler/CGI set Content-Length (e.g. mvsMF's `sendDefaultHeaders()`) → use as-is
 2. If static file with known size (UFS `filesize`) → send Content-Length
 3. Otherwise → send `Transfer-Encoding: chunked`

--- a/src/httpprtv.c
+++ b/src/httpprtv.c
@@ -26,9 +26,19 @@ httpprtv(HTTPC *httpc, const char *fmt, va_list args)
            and inject Transfer-Encoding: chunked for HTTP/1.1 if needed */
         if (len == 2 && buf[0] == '\r' && buf[1] == '\n'
             && httpc->resp > 0 && !httpc->rdw) {
+            /* Responses that never carry a message body (RFC 7230 3.3.1):
+               1xx, 204 No Content and 304 Not Modified. These must not be
+               chunked: injecting Transfer-Encoding: chunked makes httpdone()
+               append a "0\r\n\r\n" terminator, which is an illegal body and
+               is rejected by strict HTTP parsers (e.g. llhttp / Node.js).
+               NOTE: a response to HEAD is body-less too — add it here if HEAD
+               ever returns a real status (it currently returns 501). */
+            int bodyless = httpc->resp == 204 || httpc->resp == 304
+                         || (httpc->resp >= 100 && httpc->resp < 200);
+
             httpc->rdw = 1; /* headers ended — don't re-trigger */
 
-            if (!httpc->content_length_set && !httpc->chunked) {
+            if (!bodyless && !httpc->content_length_set && !httpc->chunked) {
                 UCHAR *ver = http_get_env(httpc, "REQUEST_VERSION");
                 if (ver && http_cmp(ver, "HTTP/1.1") == 0) {
                     /* inject Transfer-Encoding header before blank line */


### PR DESCRIPTION
Fixes #65

## Problem

Under HTTP/1.1, the chunked auto-fallback in `httpprtv.c` injected
`Transfer-Encoding: chunked` whenever neither `Content-Length` nor chunked was
already set — without excluding responses that cannot carry a body. For a
`204 No Content`, `httpdone.c` then appended a `0\r\n\r\n` terminator, an illegal
body that strict parsers (llhttp / Node.js, used by current Zowe CLI & Explorer)
reject with `HPE_CLOSED_CONNECTION` / `Data after 'Connection: close'` /
`Expected HTTP/, RTSP/ or ICE/`. The MVS operation succeeded, but PUT/DELETE
appeared to fail in Zowe.

## Fix

Skip the chunked fallback for body-less status codes (`1xx`, `204`, `304`) in
`httpprtv.c`. With chunked never enabled for these, `httpdone.c` emits no
terminator — `httpc->chunked` has a single writer, so `httpdone.c` is left
unchanged. The resulting 204 has no `Content-Length`, no `Transfer-Encoding`
and no body, which is RFC 7230 §3.3.1/§3.3.2-compliant and self-delimiting
(works with both keep-alive and close).

## Scope / notes

- **Affected:** mvsMF 204 responses — `datasetPutHandler`, `memberPutHandler`
  (PUT/write) and `datasetDeleteHandler`, `memberDeleteHandler` (DELETE).
- **Create** returns `201` with an empty chunked body, which is valid HTTP — it
  was never broken and is intentionally *not* in the body-less set.
- **Rename** is not implemented in mvsMF; not in scope.
- **HEAD** currently returns `501` (with a body); a code comment marks where to
  add it if HEAD ever returns a real status.
- mvsMF handlers need no change.
- Origin of the regression: #58 (chunked fallback) assumed mvsMF always sets
  Content-Length, which is false for 204 (`content_length = 0`).

## Verification

- `make compiledb` clean (offline); the change is a two-line guard.
- Behaviour verified by **code inspection** — needs a live confirmation:
  `zowe zos-files upload` / `delete` against HTTPD 4.0.0 + mvsMF should now
  succeed without `Failed to send an HTTP request.`
- `curl` does **not** reproduce the original failure (lenient parser) — that is
  why mvsMF's curl tests passed throughout. Suggested regression artifact
  (separate, in `mvsmf/tests`): assert that a 204 PUT/DELETE response carries no
  `Transfer-Encoding` header.
