### PR TITLE
Migrate to mbt v2 (cc370 host build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ compile_commands.json
 
 # Build system (mbt)
 .mbt/
+build/
 contrib/
 dist/
 *.xmit

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 MBT_ROOT := mbt
-include $(MBT_ROOT)/mk/core.mk
+include $(MBT_ROOT)/mk/mbt.mk

--- a/mbt.lock
+++ b/mbt.lock
@@ -1,0 +1,6 @@
+{
+  "mvslovers/ufsd": {
+    "sha256": "c8c8371d19f8b3212eaa1bfa9765ab6a49a2f5a0e11d0083b0f5f85f320ae3ac",
+    "version": "1.0.0-dev"
+  }
+}

--- a/project.toml
+++ b/project.toml
@@ -18,6 +18,10 @@ cflags = ["-I", "include", "-I", "credentials/include"]
 # v1 NCALIB-autocall model; never shipped (the public client lib is [lib]).
 [internal]
 sources = ["src/*.c", "credentials/src/*.c"]
+# cgistart is the CGI launcher: a per-module root (force-included by each CGI
+# module) AND shipped in [lib] for external CGIs.  Keep it OUT of the autocall
+# pool so its @@START can never shadow another module's entry.
+exclude = ["src/cgistart.c"]
 
 # -- Load Modules -------------------------------------------------
 # v1 'include = ["@@CRT1", <members>]' -> startup = "crt1" + the member
@@ -57,15 +61,17 @@ name = "HTTPDSRV"
 startup = "crt1"
 sources = ["src/cgistart.c", "src/httpdsrv.c"]
 
-# -- Public header export -----------------------------------------
+# -- Public CGI SDK export ----------------------------------------
 # What httpd ships for consumers (e.g. mvsmf, which declares
-# "mvslovers/httpd" in its [dependencies]).  httpd exposes no client
-# archive: a CGI reaches the http_* API at runtime through the httpx
-# callback table the server fills in (see cgistart.c), so consumers
-# compile against these headers and link nothing from httpd.
-# Headers-only [lib] -- no sources, no .a (replaces v1 [artifacts]).
+# "mvslovers/httpd" in its [dependencies]).  The client library is the
+# CGI launcher cgistart.o plus the public headers: a CGI program links
+# cgistart (which provides __start, builds argv, and calls the program's
+# main()) and reaches the http_* API at runtime through the httpx
+# callback table (http_get_httpx()).  cgistart uses only the public API
+# (httpcgi.h), so external CGIs need not copy it -- they link this object.
 [lib]
 name = "httpd"
+sources = ["src/cgistart.c"]
 headers = [
 	"include/httpcgi.h",
 	"include/httpxlat.h",

--- a/project.toml
+++ b/project.toml
@@ -4,100 +4,75 @@ version = "4.0.0-dev"
 type = "application"
 
 [build]
-cflags = [
-	"-O1",
-	"-I./include",
-	"-I./credentials/include",
-]
-
-[build.sources]
-c_dirs = ["src/", "credentials/src/"]
-
-[mvs.build.datasets.source]
-suffix = "SOURCE"
-dsorg = "PO"
-recfm = "FB"
-lrecl = 80
-blksize = 19040
-space = ["TRK", 600, 100, 200]
-
-[mvs.build.datasets.punch]
-suffix = "OBJECT"
-dsorg = "PO"
-recfm = "FB"
-lrecl = 80
-blksize = 19040
-space = ["TRK", 100, 50, 200]
-
-[mvs.build.datasets.ncalib]
-suffix = "NCALIB"
-dsorg = "PO"
-recfm = "U"
-lrecl = 0
-blksize = 19069
-space = ["TRK", 100, 50, 200]
-
-[mvs.build.datasets.syslmod]
-suffix = "LOAD"
-dsorg = "PO"
-recfm = "U"
-lrecl = 0
-blksize = 15040
-space = ["TRK", 150, 50, 30]
+cflags = ["-I", "include", "-I", "credentials/include"]
 
 [dependencies]
-"mvslovers/crent370" = ">=1.0.9"
 "mvslovers/ufsd" = "=1.0.0-dev"
 
-# --- Load Modules ------------------------------------------------
+# -- Internal autocall archive ------------------------------------
+# All of httpd's objects, archived into build/httpdint.a.  Every module
+# autocalls it: each [[module]] below lists only its own root source(s)
+# (each root defines its own main(), so they cannot be globbed into one
+# module), and the linker pulls the shared rest from this archive by
+# autocall (referenced members only -> minimal load modules).  Mirrors the
+# v1 NCALIB-autocall model; never shipped (the public client lib is [lib]).
+[internal]
+sources = ["src/*.c", "credentials/src/*.c"]
 
-# Main HTTPD server
-[[link.module]]
+# -- Load Modules -------------------------------------------------
+# v1 'include = ["@@CRT1", <members>]' -> startup = "crt1" + the member
+# roots as 'sources'; the shared body resolves from [internal] by autocall.
+
+# Main HTTPD server (APF-authorized)
+[[module]]
 name = "HTTPD"
-entry = "@@CRT0"
-options = ["SIZE=(4000K,40K)", "LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "HTTPSTRT", "HTTPD", "HTTPPRM"]
-setcode = "AC(1)"
-
-[link.module.dep_includes]
-"mvslovers/ufsd" = "*"
+startup = "crt1"
+sources = ["src/httpstrt.c", "src/httpd.c", "src/httpprm.c"]
+ac = 1
 
 # JES2 CGI handler
-[[link.module]]
+[[module]]
 name = "HTTPJES2"
-entry = "@@CRT0"
-options = ["LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "CGISTART", "HTTPJES2"]
+startup = "crt1"
+sources = ["src/cgistart.c", "src/httpjes2.c"]
 
-# SSI handler modules
-[[link.module]]
+# SSI handler modules (CGI programs sharing the cgistart launcher)
+[[module]]
 name = "HTTPDM"
-entry = "@@CRT0"
-options = ["LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "CGISTART", "HTTPDM"]
+startup = "crt1"
+sources = ["src/cgistart.c", "src/httpdm.c"]
 
-[[link.module]]
+[[module]]
 name = "HTTPDMTT"
-entry = "@@CRT0"
-options = ["LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "CGISTART", "HTTPDMTT"]
+startup = "crt1"
+sources = ["src/cgistart.c", "src/httpdmtt.c"]
 
-[[link.module]]
+[[module]]
 name = "HTTPDSL"
-entry = "@@CRT0"
-options = ["LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "CGISTART", "HTTPDSL"]
+startup = "crt1"
+sources = ["src/cgistart.c", "src/httpdsl.c"]
 
-[[link.module]]
+[[module]]
 name = "HTTPDSRV"
-entry = "@@CRT0"
-options = ["LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "CGISTART", "HTTPDSRV"]
+startup = "crt1"
+sources = ["src/cgistart.c", "src/httpdsrv.c"]
+
+# -- Public header export -----------------------------------------
+# What httpd ships for consumers (e.g. mvsmf, which declares
+# "mvslovers/httpd" in its [dependencies]).  httpd exposes no client
+# archive: a CGI reaches the http_* API at runtime through the httpx
+# callback table the server fills in (see cgistart.c), so consumers
+# compile against these headers and link nothing from httpd.
+# Headers-only [lib] -- no sources, no .a (replaces v1 [artifacts]).
+[lib]
+name = "httpd"
+headers = [
+	"include/httpcgi.h",
+	"include/httpxlat.h",
+	"include/dbg.h",
+	"include/errors.h",
+	"include/types.h",
+]
 
 [release]
 version_files = ["VERSION"]
-
-[artifacts]
-headers = true
-header_files = ["httpcgi.h", "httpxlat.h", "dbg.h", "errors.h", "types.h"]
-loads = true

--- a/src/cgistart.c
+++ b/src/cgistart.c
@@ -23,7 +23,13 @@
    the EXEC statement in the JCL.
 */
 
-#include "httpd.h"
+#include <stdlib.h>
+#include <string.h>
+#include <clibgrt.h>
+#include <clibppa.h>
+#include <clibary.h>
+#include <clibenv.h>
+#include "httpcgi.h"
 
 #define MAXPARMS 50 /* maximum number of arguments we can handle */
 
@@ -36,7 +42,7 @@ HTTPX *httpx = 0;
 /* we want to use the httpx pointer in the httpd struct for the various
    http_xxx functions, so we define httpx to do just that
 */
-#define httpx   (httpd->httpx)
+#define httpx   http_get_httpx(httpd)
 
 /* we want the internal label for __start as "cgistart" for use with dumps */
 __asm__("\n&FUNC    SETC 'cgistart'");


### PR DESCRIPTION
Closes #67. Depends on mvslovers/mbt#48 (merged).

Migrates httpd to the mbt v2 host build (cc370/as370/ld370/ar370). MVS is touched only by `make deploy`.

## Module composition

httpd has 6 load modules sharing a large common body of code, where every module root defines its own `main()` — so the shared code can't be globbed into each module. Uses the new `[internal]` autocall archive: each `[[module]]` lists only its root source(s) and the linker pulls the shared rest (105 → 104 objects) by autocall, mirroring v1's NCALIB model.

- HTTPD (server) + HTTPJES2, HTTPDM, HTTPDMTT, HTTPDSL, HTTPDSRV (CGI handlers), all `crt1`.
- HTTPD keeps AC(1), RENT, REUS.
- crent370 leaves `[dependencies]` (cc370 sysroot); ufsd stays as the one real dependency.

## CGI SDK library

`[lib]` exports the public headers **and** `cgistart.o`. `cgistart.c` is decoupled to the public API (`httpcgi.h` + `http_get_httpx()` instead of internal `httpd.h` + `httpd->httpx`) — ABI-identical object, but external CGI programs (mvsmf) can now link httpd's launcher instead of copying it (`mvsmf/src/cgxstart.c`). cgistart is `exclude`d from `[internal]` so its `@@START` never shadows another module's entry.

## Removed / changed

- `Makefile` → `mk/mbt.mk`; `[mvs.build.datasets.*]` blocks removed.
- `mbt` submodule bumped to v2.
- `build/` added to `.gitignore`; `mbt.lock` committed (dependency source-of-record).

## Verification

All 6 modules build clean; deployed to `IBMUSER.HTTPD.V4R0M0D.LINKLIB` and smoke-tested on the live MVS system.
