### PR TITLE
Generic per-CGI context registrar: http_cgictx_get

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -203,6 +203,9 @@ Server modules call server functions through the HTTPX function vector. Key func
 **UFS:**
 - `http_open(httpc, path, mime)` — open a UFS file for serving
 
+**Cross-request context:**
+- `http_cgictx_get(httpd, eye, size)` — find or create one context block per 8-byte eyecatcher. A module that needs a single, address-space-lifetime block (shared across requests and workers) registers it here. The block begins with the 8-byte eyecatcher (`char eye[8]`, stamped on create); `size` is used only on create and ignored on a hit, so always pass the same size for the same eyecatcher. The block is zeroed on create, lives until the address space ends, and is never freed individually. Returns the block, or `NULL` if the context array is full or storage is exhausted. Example: `http_cgictx_get(httpd, "MVSMFCTX", sizeof(MVSMF_CTX))`.
+
 ### Building a Server Module
 
 Create a `project.toml` with dependencies on `crent370` and `httpd`:

--- a/include/httpcgi.h
+++ b/include/httpcgi.h
@@ -295,6 +295,8 @@ struct httpx {
     HTTPCP      *xlate_legacy;      /* 11C legacy hybrid codepage pair  */
     UFS *       (*http_get_ufs)(HTTPC *);
                                     /* 120 get/create UFS handle        */
+    void *      (*http_cgictx_get)(HTTPD *, const char *, unsigned);
+                                    /* 124 find/create CGI context      */
 };
 
 /* Eye-catcher for HTTPD pointer identification (ABI constant) */
@@ -518,5 +520,8 @@ struct httpx {
 
 #define http_get_ufs(httpc) \
     ((httpx->http_get_ufs)((httpc)))
+
+#define http_cgictx_get(httpd,eye,size) \
+    ((httpx->http_cgictx_get)((httpd),(eye),(size)))
 
 #endif /* HTTPCGI_H */

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -141,7 +141,6 @@ struct httpd {
     void        *unused_94;         /* 94 (was: HTTPT *httpt)       */
     CTHDTASK    *self;              /* 98 HTTPD main thread         */
     void        **cgictx;           /* 9C array of CGI context ptrs */
-#define HTTPD_CGICTX_MVSMF  0       /* ... MVSMF CGI context index  */
 #define HTTPD_CGICTX_MIN    0       /* ... minimum number of cgictx */
 #define HTTPD_CGICTX_MAX    255     /* ... maximum number of cgictx */
     char        docroot[128];       /* A0 UFS document root prefix  */
@@ -415,6 +414,8 @@ struct httpx {
     HTTPCP      *xlate_legacy;      /* 11C legacy hybrid codepage pair  */
     UFS *       (*http_get_ufs)(HTTPC *);
                                     /* 120 get/create UFS handle    */
+    void *      (*http_cgictx_get)(HTTPD *, const char *, unsigned);
+                                    /* 124 find/create CGI context  */
 };
 
 extern int http_in(HTTPC*)                                              asm("HTTPIN");
@@ -475,6 +476,7 @@ extern HTTPCGI *http_add_cgi(HTTPD *httpd, const char *pgm, const char *path, in
 extern int http_process_cgi(HTTPC *httpc, HTTPCGI *cgi)                 asm("HTTPPCGI");
 extern unsigned char *http_xlate(unsigned char *, int, const unsigned char *) asm("HTTPXLAT");
 extern UFS *http_get_ufs(HTTPC *)                                          asm("HTTPGUFS");
+extern void *http_cgictx_get(HTTPD *, const char *, unsigned)              asm("HTTPGCTX");
 extern double httpsecs(double *psecs)									asm("HTTPSECS");
 extern int httpcred(HTTPC *httpc)										asm("HTTPCRED");
 extern int httpd048(HTTPD *httpd)										asm("HTTPD048");
@@ -700,6 +702,9 @@ extern int http_gets(HTTPC *httpc, UCHAR *buf, unsigned max)            asm("HTT
 
 #define http_get_ufs(httpc) \
     ((httpx->http_get_ufs)((httpc)))
+
+#define http_cgictx_get(httpd,eye,size) \
+    ((httpx->http_cgictx_get)((httpd),(eye),(size)))
 
 #endif  /* ifndef HTTPX_H */
 

--- a/project.toml
+++ b/project.toml
@@ -63,6 +63,15 @@ name = "HTTPDSRV"
 startup = "crt1"
 sources = ["src/cgistart.c", "src/httpdsrv.c"]
 
+# -- Tests --------------------------------------------------------
+# http_cgictx_get() registrar.  Uses lock()/__getm() (MVS SVCs), so it is
+# MVS-only (make test-mvs); the host build is skipped (it pulls httpd.h's
+# crent370 internals).  http_cgictx_get resolves from the [internal] autocall
+# archive, so only the test root is listed here.
+[[test]]
+name = "TSTGCTX"
+sources = ["test/mvs/tstgctx.c"]
+
 # -- Public CGI SDK export ----------------------------------------
 # What httpd ships for consumers (e.g. mvsmf, which declares
 # "mvslovers/httpd" in its [dependencies]).  The client library is the

--- a/project.toml
+++ b/project.toml
@@ -20,10 +20,14 @@ cflags = ["-I", "include", "-I", "credentials/include", '-DVERSION=\"$(PROJECT_V
 # v1 NCALIB-autocall model; never shipped (the public client lib is [lib]).
 [internal]
 sources = ["src/*.c", "credentials/src/*.c"]
-# cgistart is the CGI launcher: a per-module root (force-included by each CGI
-# module) AND shipped in [lib] for external CGIs.  Keep it OUT of the autocall
-# pool so its @@START can never shadow another module's entry.
-exclude = ["src/cgistart.c"]
+# Module entry points are kept OUT of the autocall pool so their custom __start
+# can never shadow another module's (or a test's) entry by autocall:
+#   - cgistart: the CGI launcher (a per-module root, also shipped in [lib]).
+#   - httpstrt: HTTPD's own __start (rejects SYSPRINT, opens HTTPDOUT/ERR/IN).
+# The HTTPD module lists httpstrt.c in its own [[module]] sources, so it still
+# gets it; everything else (CGI modules, [[test]] modules) resolves the default
+# libc __start instead.
+exclude = ["src/cgistart.c", "src/httpstrt.c"]
 
 # -- Load Modules -------------------------------------------------
 # v1 'include = ["@@CRT1", <members>]' -> startup = "crt1" + the member

--- a/src/httpgctx.c
+++ b/src/httpgctx.c
@@ -1,0 +1,64 @@
+/* HTTPGCTX.C
+** Generic per-CGI context registrar (find-or-create by eyecatcher)
+*/
+#define HTTP_PRIVATE
+#include "httpd.h"
+#include "mvssupa.h"                /* __getm() raw GETMAIN in subpool 0    */
+
+__asm__("\n&FUNC SETC 'HTTPGCTX'");
+
+#undef http_cgictx_get
+
+/*
+** http_cgictx_get() - find or create one context block per 8-byte eyecatcher.
+**
+** httpd knows neither the type nor the name of any CGI -- only 8 bytes to
+** match and a size to allocate.  Every context block begins with the 8
+** eyecatcher bytes (stamped here on create); `size` is used ONLY on create
+** and ignored on a hit (caller contract: always pass the same size for the
+** same eyecatcher).
+**
+** The block is allocated with __getm() (raw GETMAIN, subpool 0).  SP0 is
+** shared address-space wide (SZERO=YES on the worker ATTACH), so the block
+** outlives the LINK return that started the CGI and the worker shrink, and
+** lives until the address space ends.  __getm() bypasses the malloc memmgr,
+** so @@exit never reclaims it -- exactly why __getm() and not malloc().  A
+** context block is therefore never freed individually.
+**
+** The whole find-or-create runs under one lock on the array address
+** (CLIBLOCK ENQ, STEP scope), so concurrent workers cannot race and there is
+** no loser-free case.
+**
+** Returns the existing or newly created block, or NULL (array full / no core).
+*/
+void *
+http_cgictx_get(HTTPD *httpd, const char *eye, unsigned size)
+{
+    void **slot = NULL;
+    void  *ctx  = NULL;
+    int    i;
+
+    if (!httpd || !httpd->cgictx) return NULL;
+
+    lock(&httpd->cgictx, LOCK_EXC);     /* STEP-scope, serialize workers     */
+
+    for (i = 0; i <= httpd->cfg_cgictx; i++) {
+        void *c = httpd->cgictx[i];
+        if (c) {
+            if (memcmp(c, eye, 8) == 0) { ctx = c; goto done; }  /* existing  */
+        } else if (!slot) {
+            slot = &httpd->cgictx[i];   /* remember first free slot           */
+        }
+    }
+    if (!slot) goto done;               /* array full -> NULL                 */
+
+    ctx = __getm(size);                 /* SP0 shared -> AS lifetime          */
+    if (!ctx) goto done;
+    memset(ctx, 0, size);
+    memcpy(ctx, eye, 8);                /* stamp eyecatcher                   */
+    *slot = ctx;
+
+done:
+    unlock(&httpd->cgictx, LOCK_EXC);
+    return ctx;
+}

--- a/src/httpx.c
+++ b/src/httpx.c
@@ -78,6 +78,7 @@ static HTTPX vect = {
     &http_cp1047,               /* 118 IBM-1047 codepage pair       */
     &http_legacy,               /* 11C legacy hybrid codepage pair  */
     http_get_ufs,               /* 120 http_get_ufs()               */
+    http_cgictx_get,            /* 124 http_cgictx_get()            */
 };
 
 HTTPX *httpx = &vect;

--- a/test/mvs/tstgctx.c
+++ b/test/mvs/tstgctx.c
@@ -1,0 +1,72 @@
+/* TSTGCTX.C
+** Tests for http_cgictx_get() -- the generic per-CGI context registrar.
+**
+** Verifies invariants 1-4 from issue #70:
+**   1. repeated calls with the same eyecatcher return the SAME pointer
+**   2. different eyecatchers return DIFFERENT blocks
+**   3. a full array returns NULL (no abend, no overwrite)
+**   4. a freshly created block is zeroed and stamped with the eyecatcher
+**
+** lock()/__getm() are MVS SVCs, so this is an MVS-only test (make test-mvs).
+** HTTP_PRIVATE is defined so http_cgictx_get() resolves to the real HTTPGCTX
+** entry (called directly) instead of the httpx-vector macro.
+*/
+#define HTTP_PRIVATE
+#include "httpd.h"
+#include <mbtcheck.h>
+
+int main(void)
+{
+    HTTPD   httpd;
+    void    *p1, *p1b, *p2, *p3, *p4, *p5;
+    int     zeroed;
+    int     i;
+
+    printf("=== HTTPD http_cgictx_get tests ===\n");
+
+    /* minimal server: a small CGI context array (cfg_cgictx 3 -> 4 slots) */
+    memset(&httpd, 0, sizeof(httpd));
+    httpd.cfg_cgictx = 3;
+    httpd.cgictx = (void **) calloc(httpd.cfg_cgictx + 1, sizeof(void *));
+    CHECK(httpd.cgictx != NULL, "cgictx array allocated");
+    if (!httpd.cgictx) return mbt_test_summary("TSTGCTX");
+
+    /* create a first block */
+    p1 = http_cgictx_get(&httpd, "TSTCTX01", 32);
+    CHECK(p1 != NULL, "create returns a non-NULL block");
+
+    /* invariant 4: eyecatcher stamped in bytes 0-7 */
+    CHECK(p1 && memcmp(p1, "TSTCTX01", 8) == 0,
+          "new block carries the eyecatcher in bytes 0-7");
+
+    /* invariant 4: bytes past the eyecatcher are zeroed */
+    zeroed = (p1 != NULL);
+    for (i = 8; p1 && i < 32; i++) {
+        if (((unsigned char *)p1)[i] != 0) zeroed = 0;
+    }
+    CHECK(zeroed, "new block is zeroed past the eyecatcher");
+
+    /* invariant 1: same eyecatcher -> same pointer */
+    p1b = http_cgictx_get(&httpd, "TSTCTX01", 32);
+    CHECK(p1b == p1, "same eyecatcher returns the same pointer");
+
+    /* invariant 2: a different eyecatcher -> a different block */
+    p2 = http_cgictx_get(&httpd, "TSTCTX02", 32);
+    CHECK(p2 != NULL && p2 != p1, "different eyecatcher returns a different block");
+
+    /* fill the remaining slots (slots 2 and 3 of 0..3) */
+    p3 = http_cgictx_get(&httpd, "TSTCTX03", 32);
+    p4 = http_cgictx_get(&httpd, "TSTCTX04", 32);
+    CHECK(p3 != NULL && p4 != NULL && p3 != p4,
+          "remaining slots allocate distinct blocks");
+
+    /* invariant 3: array full -> NULL, no abend */
+    p5 = http_cgictx_get(&httpd, "TSTCTX05", 32);
+    CHECK(p5 == NULL, "full array returns NULL");
+
+    /* invariant 3: a full array must not overwrite existing entries */
+    CHECK(http_cgictx_get(&httpd, "TSTCTX01", 32) == p1,
+          "existing entry still found after the array filled");
+
+    return mbt_test_summary("TSTGCTX");
+}


### PR DESCRIPTION
Fixes #70

## What

Adds `http_cgictx_get(httpd, eye, size)` — a generic, name-identified context slot that lets a CGI register *one* cross-request, address-space-lifetime data block, without httpd knowing the CGI's type or name.

```c
void *http_cgictx_get(HTTPD *httpd, const char *eye, unsigned size);
```

Find-or-create one context block per 8-byte eyecatcher in the existing `httpd->cgictx` array. Each block begins with the 8 eyecatcher bytes (stamped on create); `size` is used only on create and ignored on a hit. Returns the block, or `NULL` (array full / no core).

## Why

Removes the layering violation where `HTTPD_CGICTX_MVSMF` named a specific CGI inside the server. That constant was **defined but unused** (no `cgictx[i] = …` anywhere in the server), so there was nothing to migrate — it is simply removed. `HTTPD_CGICTX_MIN` / `HTTPD_CGICTX_MAX` (array sizing / Parmlib) are kept.

## How it stays alive / safe

- **Lifetime:** blocks come from `__getm()` (raw GETMAIN, subpool 0). SP0 is shared address-space wide (`SZERO=YES` on the worker ATTACH), so a block outlives the LINK return that started the CGI and the worker shrink, and lives until the address space ends. `__getm()` bypasses the malloc memmgr, so `@@exit` never reclaims it — exactly why `__getm()`, not `malloc()`. A block is never freed individually.
- **Concurrency:** the whole find-or-create runs under one `lock(&httpd->cgictx, LOCK_EXC)` (CLIBLOCK ENQ, STEP scope), so concurrent workers cannot race and there is no loser-free case. The match check precedes the free-slot scan, so a full array still returns an existing block for a known eyecatcher.
- **RENT/REUS:** no writable static/global; the only mutable state is the `__getm` block plus the existing `cgictx` array.

## HTTPX ABI — append-only (offsets unchanged)

New pointer appended at offset `0x124`, after `http_get_ufs` (`0x120`), in **both** `include/httpd.h` and `include/httpcgi.h`; no existing offset moves. Installed last in the `src/httpx.c` initializer (positional).

```diff
     UFS *       (*http_get_ufs)(HTTPC *);
                                     /* 120 get/create UFS handle    */
+    void *      (*http_cgictx_get)(HTTPD *, const char *, unsigned);
+                                    /* 124 find/create CGI context  */
 };
```

## Build-config fix (second commit)

Exposed by the new test: `src/httpstrt.c` (HTTPD's custom `__start`, which rejects `SYSPRINT` and opens `HTTPDOUT`/`HTTPDERR`/`HTTPDIN`) was sitting in the `[internal]` autocall archive. Any `crt0`/`crt1` consumer that doesn't bring its own entry — like a `[[test]]` — leaves `__start` unresolved, so the linker pulled HTTPD's `__start` from the archive ahead of the default libc one, and the test bailed with `EXIT_FAILURE` before `main()`.

`[internal]` now excludes **both** module entry points (`cgistart.c`, `httpstrt.c`) for the same anti-shadowing reason. The HTTPD module lists `httpstrt.c` in its own `[[module]]` sources, so its load module is unchanged.

## Tests

`TSTGCTX` (`test/mvs/tstgctx.c`, `mbtcheck.h`) covers the find-or-create invariants: same eyecatcher → same pointer; different eyecatcher → different block; full array → `NULL` (no overwrite); fresh block zeroed and eyecatcher-stamped in bytes 0–7.

`lock`/`__getm` are MVS SVCs, so **TSTGCTX is MVS-only** and runs via `make test-mvs`. It resolves `http_cgictx_get` from the `[internal]` autocall archive, so only the test root is listed in `project.toml`. (A `make check` run will fail TSTGCTX's host-compile leg by design — `httpd.h` pulls crent370 internals absent on the host.)

## Verification

- `make` (modules) + `make test` — green with the cc370 toolchain (CI's gate). HTTPD still links cleanly with `httpstrt` excluded from the autocall pool.
- `make test-mvs` against a live MVS target — **TSTGCTX 9/9 passed on both legs** (batch `B01` CC 0, TSO `T01` CC 0; 18/18 assertions). Invariants 1–4 confirmed at runtime.

## Follow-up

The mvsMF follow-up (separate repo) can now call:

```c
http_cgictx_get(httpd, "MVSMFCTX", sizeof(MVSMF_CTX));
```