### PR TITLE
Seed HTTPD unit tests: TSTDECO + host=false skip for MVS-only tests

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -75,6 +75,17 @@ sources = ["src/cgistart.c", "src/httpdsrv.c"]
 [[test]]
 name = "TSTGCTX"
 sources = ["test/mvs/tstgctx.c"]
+host = false            # uses lock()/__getm() SVCs -> MVS-only (test-mvs)
+
+# http_decode() / httpdeco() URI percent+plus decoder.  MVS-target like
+# TSTGCTX: httpdeco pulls no SVCs, but it is reached through httpd.h (crent370
+# runtime headers, not host-portable), so the host build cannot compile it.
+# httpdeco (HTTPDECO) and asc2ebc resolve from the [internal] autocall archive,
+# so only the test root is listed here.
+[[test]]
+name = "TSTDECO"
+sources = ["test/tstdeco.c"]
+host = false            # httpd.h -> crent370 internals -> MVS-only (test-mvs)
 
 # -- Public CGI SDK export ----------------------------------------
 # What httpd ships for consumers (e.g. mvsmf, which declares

--- a/test/tstdeco.c
+++ b/test/tstdeco.c
@@ -1,0 +1,87 @@
+/* TSTDECO.C
+** Tests for http_decode() / httpdeco() -- the in-place URI percent/plus
+** decoder (src/httpdeco.c).
+**
+** Contract exercised:
+**   - "+"    decodes to a space
+**   - "%xx"  decodes to asc2ebc[<hex>] (the ASCII code is mapped to EBCDIC
+**            via the active codepage table), consuming both hex digits
+**   - ordinary bytes pass through unchanged
+**   - the result is decoded in place and NUL-terminated
+**
+** EBCDIC note: httpdeco emits asc2ebc[...] for a "%xx" escape, so the expected
+** value of a decoded escape MUST be written as asc2ebc[<code>] (never a bare
+** hex literal) to stay correct on both cc370 (EBCDIC) and a host build. The
+** "+", pass-through and length checks use character literals, which the
+** compiler encodes for the target -- so they hold on either platform.
+**
+** httpdeco() pulls no SVCs, but it is reached here through httpd.h (which drags
+** in the crent370 runtime headers), so like TSTGCTX this is an MVS-target test
+** (make test-mvs); asc2ebc and HTTPDECO resolve from the [internal] autocall
+** archive, so only the test root is listed in project.toml.
+**
+** HTTP_PRIVATE selects the real HTTPDECO entry (called directly) instead of the
+** httpx-vector macro.
+*/
+#define HTTP_PRIVATE
+#include "httpd.h"
+#include <mbtcheck.h>
+
+int main(void)
+{
+    UCHAR buf[64];
+
+    printf("=== HTTPD http_decode tests ===\n");
+
+    /* pass-through: no escapes, unchanged */
+    strcpy((char *)buf, "hello");
+    http_decode(buf);
+    CHECK(strcmp((char *)buf, "hello") == 0, "plain text passes through");
+
+    /* '+' decodes to a space */
+    strcpy((char *)buf, "a+b");
+    http_decode(buf);
+    CHECK(strcmp((char *)buf, "a b") == 0, "'+' decodes to space");
+
+    /* a single "%xx" escape -> asc2ebc[code], both hex digits consumed */
+    strcpy((char *)buf, "%41");
+    http_decode(buf);
+    CHECK(strlen((char *)buf) == 1, "one escape yields one byte");
+    CHECK(buf[0] == asc2ebc[0x41], "%41 decodes to asc2ebc[0x41]");
+
+    /* two adjacent escapes decode independently, in order */
+    strcpy((char *)buf, "%41%42");
+    http_decode(buf);
+    CHECK(strlen((char *)buf) == 2, "two escapes yield two bytes");
+    CHECK(buf[0] == asc2ebc[0x41] && buf[1] == asc2ebc[0x42],
+          "adjacent escapes decode in order");
+
+    /* mixed literal + escape + literal */
+    strcpy((char *)buf, "a%20b");
+    http_decode(buf);
+    CHECK(strlen((char *)buf) == 3, "mixed input keeps surrounding literals");
+    CHECK(buf[0] == 'a' && buf[1] == asc2ebc[0x20] && buf[2] == 'b',
+          "%20 decodes between two literals");
+
+    /* lowercase hex digits are accepted */
+    strcpy((char *)buf, "%2f");
+    http_decode(buf);
+    CHECK(buf[0] == asc2ebc[0x2f], "lowercase hex escape decodes");
+
+    /* case-insensitivity: %2F and %2f agree */
+    strcpy((char *)buf, "%2F");
+    http_decode(buf);
+    CHECK(buf[0] == asc2ebc[0x2f], "uppercase hex escape decodes the same");
+
+    /* boundary: a trailing '%' with no hex digits (relates to S5 in the
+       refactoring backlog). Current contract: the escape is not advanced,
+       the leading literal survives, and no crash occurs. buf is padded so
+       the decoder's str[2] look-ahead stays inside this array. When S5 is
+       fixed this assertion is updated to the new trailing-'%' contract. */
+    memset(buf, 0, sizeof(buf));
+    strcpy((char *)buf, "a%");
+    http_decode(buf);
+    CHECK(buf[0] == 'a', "trailing '%' keeps the preceding literal (no crash)");
+
+    return mbt_test_summary("TSTDECO");
+}


### PR DESCRIPTION
## What

Seeds an HTTPD unit-test suite (rexx370-style), starting with **`TSTDECO`** for the URI percent/plus decoder, and makes `make test-host` usable for httpd again.

## Why

httpd had one test (`TSTGCTX`) and `make test-host` was **red** because of it: unlike rexx370's modular, host-portable headers, httpd's `httpd.h` is a kitchen-sink header pulling the full crent370/libc370 runtime stack (own `size_t`, incompatible `snprintf`, `time64.h`, `socket.h`, …) which does not compile with a host compiler. Any test reaching through `httpd.h` is therefore **MVS-target** (`make test-mvs`), and the pinned mbt had no way to mark it so — the pure-C `TSTGCTX` just `FAIL COMPILE`d on host.

## Changes

- **`test/tstdeco.c`** — 8 checks for `http_decode()` / `httpdeco()`: pass-through, `+`→space, `%xx`→`asc2ebc[…]`, adjacent + mixed escapes, lower/upper-case hex, and the trailing-`%` boundary (relates to **S5** in `docs/refactoring-backlog.md`). Decoded-escape expectations use `asc2ebc[…]` (never bare hex literals) so they are EBCDIC-correct on cc370.
- **mbt `ebdad21` → `d57d447`** — test-infra only (2 commits, 3 files: `mbttest.py`, `mbttesthost.py`, `docs/testing.md`; no core build/link/mk changes). Brings the `host = false` per-test skip flag.
- **`host = false`** on `TSTDECO` **and** `TSTGCTX` (both MVS-only) → `make test-host` skips them cleanly.

## Verification

- `test/tstdeco.c` compiles clean with **cc370** (exit 0, S/370 ASM emitted, only pre-existing header warnings). A full run needs `make test-mvs` on the live system — please run it there to confirm the assertions pass.
- `make test-host` → `skipped (MVS-only): TSTGCTX (host = false), TSTDECO (host = false)` … `all host tests passed` (exit 0).

## Notes for the maintainer

- The **mbt submodule bump** is the notable part — please eyeball it. It only touches test-host/test-mvs scripts; other projects (ufsd/ftpd/mvsmf) remain on `ebdad21`, rexx370 is already on `d57d447`.
- Independent of PR #73 (S1 fix); branched from `main`.

## Follow-ups

Next helper tests per the backlog: `httpcmp` (EBCDIC caseless compare), `http_mime`, base64 decode (**S3**), env-block sizing (**M9**).

Fixes #74
