### PR TITLE
Harden httpcred login/redirect path (S2 overflow+XSS, S3 header injection)

### DIFF
--- a/docs/refactoring-backlog.md
+++ b/docs/refactoring-backlog.md
@@ -63,17 +63,17 @@ listener bailing on a transient error) remains of this chain — a one-liner in
 the *Also high-value* / hardening set below.
 
 **Also high-value:**
-- `S2`/`S3` — `httpcred` login/redirect path: a `sprintf` into `buf[512]` from a
-  cookie value (overflow + reflected XSS) and an unterminated, unfiltered
-  redirect (header injection).
+- ~~`S2`/`S3` — `httpcred` login/redirect path~~ **✔ Resolved (PR #79 / issue
+  #78)** — cookie `sprintf`/XSS and the unterminated, unfiltered redirect are
+  fixed via `http_html_escape()` + `http_safe_redirect()`.
 - `M2` — the credential array has **no reaper** (unbounded CRED+ACEE growth);
   this is also the missing "session timeout" from the security backlog.
 - `P1` — environment-variable lookup is **O(n) linear** on every access — a
   clear win for static-request throughput (for CGI paths the LINK SVC, `P7`,
   dominates; profile before investing).
 
-**Counts (open/partial):** Security 11 · Memory & Stability 12 · Performance 7.
-*(S1 resolved 2026-07-02, PR #73; M1 resolved 2026-07-02, PR #77.)*
+**Counts (open/partial):** Security 9 · Memory & Stability 12 · Performance 7.
+*(2026-07-02: S1 PR #73; M1 PR #77; S2+S3 PR #79.)*
 
 ---
 
@@ -111,7 +111,14 @@ build the candidate into the size-checked buffer. Do **not** just enlarge `buf` 
 the input is unbounded; bound it. (Also guard `path` NULL/empty — see S9b.)
 
 ### S2 — Stack overflow + reflected XSS: cookie value `sprintf` into `buf[512]`
-*Critical · Open · Effort S · `httpcred.c:237,253-255` · was F-02 / CRIT(2026-04)*
+*Critical · Resolved (2026-07-02, PR #79 / issue #78) · Effort S · `httpcred.c:237,253-255` · was F-02 / CRIT(2026-04)*
+
+> **Resolved:** the fixed `buf[512]` + `sprintf` is gone. `print_body()` now
+> HTML-escapes the `Sec-Uri` cookie with the new `http_html_escape()`
+> (`src/httpesc.c`, escapes `& < > " '`, bounded + always terminated) and
+> prints the hidden field directly — no unbounded copy into a stack buffer, no
+> unescaped reflection. Verified natively (`TSTSAFE`, incl. a `"><script>`
+> breakout).
 
 ```c
 237  char buf[512];
@@ -126,7 +133,16 @@ form HTML (reflected markup/XSS).
 cookie-length limit.
 
 ### S3 — Header injection / over-read: `Sec-Uri` redirect not terminated or filtered
-*High · Open · Effort S · `httpcred.c:393-401` (+ `Location:` use) · was F-03 / audit L10*
+*High · Resolved (2026-07-02, PR #79 / issue #78) · Effort S · `httpcred.c:393-401` (+ `Location:` use) · was F-03 / audit L10*
+
+> **Resolved:** the `strncpy` (a *source* over-read — `base64_decode` returns
+> binary and does not NUL-terminate, so it scanned past the decoded allocation)
+> is replaced by a length-bounded `memcpy` of the reported decoded length +
+> explicit terminate. Before it reaches `Location:`, the target is validated by
+> the new `http_safe_redirect()` (`src/httpsrdr.c`): reject unless it is a
+> single-leading-`/` site-local path with no `//`/`/\` and no CR/LF, else fall
+> back to `/` — closing the header-injection and open-redirect. Edge-case table
+> verified natively (`TSTSAFE`).
 
 ```c
 393  buf = base64_decode(uri, strlen(uri), &len);
@@ -536,6 +552,8 @@ for frequently-called endpoints and enable mvsMF integration.
 | SSI echo empty-var (F-13) | **Mostly resolved** | `if (!*var)` — `httpfile.c:391` (see S12) |
 | Directory-index stack overflow + NULL path (S1 / S9b) | **Resolved (2026-07-02)** | bounded copy + NULL/empty guard — `httpget.c`, PR #73 / issue #72 |
 | Worker abend leaks HTTPC/socket + corrupts `busy` (M1) | **Resolved (2026-07-02)** | `try()` net + gated `http_reset_busy` before `http_close` — `httpd.c`, PR #77 / issue #76 |
+| Cookie `sprintf` overflow + reflected XSS (S2) | **Resolved (2026-07-02)** | `http_html_escape()` + direct print — `httpcred.c`/`httpesc.c`, PR #79 / issue #78 |
+| `Sec-Uri` redirect over-read + header injection / open redirect (S3) | **Resolved (2026-07-02)** | length-bounded `memcpy` + `http_safe_redirect()` — `httpcred.c`/`httpsrdr.c`, PR #79 / issue #78 |
 
 ---
 
@@ -546,18 +564,27 @@ refactorings (the working policy: **when a fix lands and a unit test is
 sensible, add it in the same PR**). Because `httpd.h` pulls the non-host-portable
 crent370/libc370 runtime stack, tests that reach through it are **MVS-target**
 (`make test-mvs`) and carry `host = false` so `make test-host` skips them
-cleanly (needs mbt ≥ `d57d447`). Assertions on decoded/translated bytes must use
-the `asc2ebc`/`ebc2asc` tables (or char literals), never bare hex — EBCDIC.
+cleanly (needs mbt ≥ `d57d447`). **Where a fix extracts a pure helper, keep that
+helper free of `httpd.h`** (only `<stddef.h>` + char literals): the test then
+runs **DUAL** (host *and* MVS), so the logic is actually *executed* on the host
+— real signal, not just a cc370 compile. Assertions on decoded/translated bytes
+must use the `asc2ebc`/`ebc2asc` tables (or char literals), never bare hex —
+EBCDIC.
 
 **Done**
 - `TSTDECO` — `http_decode()`/`httpdeco()` percent/plus decoder, incl. the **S5**
   trailing-`%` boundary (pins current behaviour; update the assertion when S5 is
-  fixed). *(PR #75 / issue #74.)*
+  fixed). MVS-target. *(PR #75 / issue #74.)*
+- `TSTSAFE` — `http_html_escape()` (**S2**) + `http_safe_redirect()` (**S3**),
+  the extracted string-safety helpers. **Dual** (runs on host + MVS); 26
+  assertions incl. an XSS breakout and the open-redirect / CRLF edge-case table.
+  *(PR #79 / issue #78.)*
 
 **Open — pure helpers, cleanly unit-testable (good next targets)**
 - **`httpcmp`/`httpcmpn`** — EBCDIC caseless compare (collation correctness; XS).
 - **`http_mime`** — extension→type mapping (table lookup; XS).
-- **`base64_decode`** — pairs with **S3** (decode length/termination edge cases).
+- *(base64 decode itself is a **libc370** function — a test belongs there, not
+  here; the httpd-side S3 sanitiser is covered by `TSTSAFE`.)*
 - **`httpnenv`** — env-block sizing math, pairs with **M9** (assert the exact
   `offsetof`-based size; guards the over-alloc fix).
 - **`httpdeco` invalid-escape** — extend `TSTDECO` when **S5** is fixed (reject /
@@ -593,9 +620,9 @@ the `asc2ebc`/`ebc2asc` tables (or char literals), never bare hex — EBCDIC.
 1. **Stability/security criticals:** ~~**S1** (bound the copy)~~ **✔ done (PR #73)**
    + ~~**M1** (`try()` net)~~ **✔ done (PR #77)** — the S1→M1 DoS leak-chain is
    broken both ways; only **M5** of that chain remains (see step 2).
-2. **Quick security wins:** **S2**, **S3** (`httpcred` `snprintf` + escape +
-   CR/LF reject), **S5**, **S6** (`vsnprintf`), **M3** (unlock/free swap),
-   **M4**, **M5** (one-line robustness). Mostly XS.
+2. **Quick security wins:** ~~**S2**, **S3** (`httpcred` escape + CR/LF
+   reject)~~ **✔ done (PR #79)**; remaining: **S5**, **S6** (`vsnprintf`),
+   **M3** (unlock/free swap), **M4**, **M5** (one-line robustness). Mostly XS.
 3. **Memory stability:** **M2** (credential reaper — also closes the
    session-timeout security gap), **M8**/**M9**/**M10** (env/CGI alloc hygiene).
 4. **Performance:** **P1** (env-lookup index — biggest CPU win), then **P2**/**P3**
@@ -643,3 +670,11 @@ placed **before** `http_close` (resetting after close is a use-after-free — se
 the M1 note). PR #77, issue #76. Counts M&S 13→12. Added a **Testing backlog**
 section and began an MVS-target unit suite (`TSTDECO`, PR #75) with the
 `host = false` skip convention.
+
+**2026-07-02:** **S2** (cookie `sprintf` overflow + reflected XSS) and **S3**
+(`Sec-Uri` redirect over-read + `Location:` header injection / open redirect)
+fixed in `httpcred.c` — extracted `http_html_escape()` (`src/httpesc.c`) and
+`http_safe_redirect()` (`src/httpsrdr.c`), replaced `strncpy` with a
+length-bounded `memcpy` (the real bug: `base64_decode` output is not
+NUL-terminated). Both helpers are host-portable → **dual** `TSTSAFE` test, run
+natively (26/26). PR #79, issue #78. Counts Security 11→9.

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -448,6 +448,9 @@ extern UCHAR *http_etoa(UCHAR *, int)                                   asm("HTT
 extern UCHAR *http_atoe(UCHAR *, int)                                   asm("HTTPATOE");
 extern int http_cmp(const UCHAR *, const UCHAR *)                       asm("HTTPCMP");
 extern int http_cmpn(const UCHAR *, const UCHAR *, int)                 asm("HTTPCMPN");
+/* internal string-safety helpers (not CGI-facing, so no HTTPX vector) */
+extern UCHAR *http_html_escape(UCHAR *, size_t, const UCHAR *)          asm("HTTPESC");
+extern int http_safe_redirect(const UCHAR *)                           asm("HTTPSRDR");
 extern int http_dbgw(const char *, int)                                 asm("DBGW");
 extern int http_dbgs(const char *)                                      asm("DBGS");
 extern int http_dbgf(const char *fmt, ...)                              asm("DBGF");

--- a/project.toml
+++ b/project.toml
@@ -87,6 +87,14 @@ name = "TSTDECO"
 sources = ["test/tstdeco.c"]
 host = false            # httpd.h -> crent370 internals -> MVS-only (test-mvs)
 
+# String-safety helpers httpesc() (HTML escape) + httpsrdr() (safe redirect).
+# Both are free of httpd.h, so this test is DUAL: it runs natively via
+# test-host AND on MVS via test-mvs.  The helper sources are listed explicitly
+# so the host build (no autocall) can link them.
+[[test]]
+name = "TSTSAFE"
+sources = ["test/tstsafe.c", "src/httpesc.c", "src/httpsrdr.c"]
+
 # -- Public CGI SDK export ----------------------------------------
 # What httpd ships for consumers (e.g. mvsmf, which declares
 # "mvslovers/httpd" in its [dependencies]).  The client library is the

--- a/src/httpcred.c
+++ b/src/httpcred.c
@@ -210,7 +210,6 @@ static const char *body2[] = {
 };
 
 static const char *body3[] = {
-	"    <input type=\"hidden\" name=\"uri\" value=\"%s\">",
 	"    <button type=\"submit\">Login</button>",
 	"    <p class=\"message\">This server uses cookies to store a security token when you login.</p>",
 	"   </div>",
@@ -234,7 +233,7 @@ print_body(HTTPD *httpd, HTTPC *httpc, const char *msg)
 	int		rc;
 	char	*p;
 	char	*uri = http_get_env(httpc, "HTTP_Cookie-Sec-Uri");
-	char	buf[512];
+	char	esc[512];
 
 	if (!uri) uri = "/";
 	
@@ -250,9 +249,16 @@ print_body(HTTPD *httpd, HTTPC *httpc, const char *msg)
 		if (rc=http_printf(httpc, " %s\n", body2[i])) goto quit;
 	}
 
+	/* The hidden field carries the client-controlled Sec-Uri cookie back to
+	   the form.  HTML-escape it (reflected XSS) and print it directly -- never
+	   sprintf an unbounded cookie value into a fixed stack buffer (overflow). */
+	http_html_escape((UCHAR *)esc, sizeof(esc), (UCHAR *)uri);
+	if (rc=http_printf(httpc,
+	        "    <input type=\"hidden\" name=\"uri\" value=\"%s\">\n", esc))
+		goto quit;
+
 	for(i=0; body3[i]; i++) {
-		sprintf(buf, body3[i], uri);
-		if (rc=http_printf(httpc, " %s\n", buf)) goto quit;
+		if (rc=http_printf(httpc, " %s\n", body3[i])) goto quit;
 	}
 
 quit:
@@ -388,20 +394,31 @@ process_post(HTTPD *httpd, HTTPC *httpc)
 #if 0
 	wtof("httpcred.c:process_post() uri=\"%s\"", uri ? uri : "(null)");
 #endif
-	/* if the uri is for "/login" then we want to redirect to "/" */
+	/* decode the Sec-Uri cookie into the post-login redirect target */
 	if (uri) {
 		buf = base64_decode(uri, strlen(uri), &len);
 		if (buf) {
-			strncpy(uribuf, buf, sizeof(uribuf));
+			/* base64_decode returns binary and does not NUL-terminate; copy
+			   exactly the decoded length (bounded) and terminate.  strncpy
+			   here would over-read buf hunting for a NUL. */
+			if (len >= sizeof(uribuf)) len = sizeof(uribuf) - 1;
+			memcpy(uribuf, buf, len);
+			uribuf[len] = 0;
 			free(buf);
 #if 0
 			wtof("httpcred.c:process_post() uribuf=\"%s\"", uribuf);
 #endif
 			uri = uribuf;
 		}
-		
-		if (http_cmpn(uri, "/login", 6)==0) {
+
+		/* only follow a safe, site-local target: reject CR/LF (Location
+		   header injection) and off-site / protocol-relative URIs (open
+		   redirect); otherwise fall back to "/" */
+		if (!http_safe_redirect((UCHAR *)uri)) {
 			uri = "/";
+		}
+		else if (http_cmpn(uri, "/login", 6)==0) {
+			uri = "/";   /* don't bounce the user back to the login page */
 		}
 	}
 	else {

--- a/src/httpesc.c
+++ b/src/httpesc.c
@@ -1,0 +1,54 @@
+/* HTTPESC.C
+** HTML-escape a string into a bounded destination buffer.
+**
+** Escapes the five characters significant in HTML text/attribute context so
+** that untrusted input (e.g. a client-supplied cookie reflected into a form)
+** cannot inject markup.  Always NUL-terminates and never writes past the
+** destination; a value too long to fit is truncated safely.
+**
+** Kept free of httpd.h (only <stddef.h> + char literals) so the pure logic
+** unit-tests on the host as well as on MVS.  Character literals are encoded
+** for the target, so it is correct under both EBCDIC (cc370) and ASCII.
+*/
+#include <stddef.h>
+
+typedef unsigned char UCHAR;
+
+/* http_html_escape() */
+UCHAR *
+httpesc(UCHAR *dst, size_t dstsize, const UCHAR *src)
+{
+    size_t      o = 0;
+    const char  *rep;
+    size_t      rlen;
+    size_t      k;
+
+    if (!dst || dstsize == 0) return dst;
+    if (!src) src = (const UCHAR *)"";
+
+    while (*src) {
+        switch (*src) {
+        case '&':  rep = "&amp;";  rlen = 5; break;
+        case '<':  rep = "&lt;";   rlen = 4; break;
+        case '>':  rep = "&gt;";   rlen = 4; break;
+        case '"':  rep = "&quot;"; rlen = 6; break;
+        case '\'': rep = "&#39;";  rlen = 5; break;
+        default:   rep = NULL;     rlen = 1; break;
+        }
+
+        /* need room for the replacement/byte plus the trailing NUL */
+        if (o + rlen >= dstsize) break;
+
+        if (rep) {
+            for (k = 0; k < rlen; k++) dst[o+k] = (UCHAR)rep[k];
+            o += rlen;
+        }
+        else {
+            dst[o++] = *src;
+        }
+        src++;
+    }
+
+    dst[o] = 0;
+    return dst;
+}

--- a/src/httpsrdr.c
+++ b/src/httpsrdr.c
@@ -1,0 +1,34 @@
+/* HTTPSRDR.C
+** Validate a redirect target is a safe, site-local path.
+**
+** Returns 1 only for a path that is safe to place in a Location: header
+** without enabling header injection or an open redirect:
+**   - must be non-empty and start with a single '/'   (site-relative)
+**   - the 2nd char must not be '/' or '\'              (//host, /\host are
+**                                                       protocol-relative;
+**                                                       browsers normalise
+**                                                       '\' to '/')
+**   - must contain no CR or LF                         (Location: splitting)
+** Anything else returns 0 and the caller should fall back to "/".
+**
+** Kept free of httpd.h (only char literals) so the pure logic unit-tests on
+** the host as well as on MVS; correct under both EBCDIC and ASCII.
+*/
+
+typedef unsigned char UCHAR;
+
+/* http_safe_redirect() */
+int
+httpsrdr(const UCHAR *uri)
+{
+    const UCHAR *p;
+
+    if (!uri || uri[0] != '/')            return 0;  /* must be site-relative */
+    if (uri[1] == '/' || uri[1] == '\\')  return 0;  /* //host or /\host      */
+
+    for (p = uri; *p; p++) {
+        if (*p == '\r' || *p == '\n')     return 0;  /* header injection      */
+    }
+
+    return 1;
+}

--- a/test/tstsafe.c
+++ b/test/tstsafe.c
@@ -1,0 +1,80 @@
+/* TSTSAFE.C
+** Tests for the string-safety helpers used by the login/redirect path:
+**   httpesc()  -- HTML-escape into a bounded buffer (src/httpesc.c)   [S2]
+**   httpsrdr() -- safe site-local redirect predicate (src/httpsrdr.c) [S3]
+**
+** Both helpers are free of httpd.h, so this is a DUAL test: it runs natively
+** via `make test-host` (real execution of the edge-case tables) and on MVS via
+** `make test-mvs`.  Assertions use character literals / literal strings, which
+** the compiler encodes for the target, so they hold under EBCDIC and ASCII.
+**
+** The real C symbols (httpesc/httpsrdr) are declared directly here so the same
+** name resolves on both the host (symbol `httpesc`) and MVS (CSECT `HTTPESC`).
+*/
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <mbtcheck.h>
+
+extern unsigned char *httpesc(unsigned char *, size_t, const unsigned char *);
+extern int            httpsrdr(const unsigned char *);
+
+/* escape src into a fresh buffer and compare against want */
+static int esc_is(const char *src, const char *want)
+{
+    unsigned char buf[64];
+    httpesc(buf, sizeof(buf), (const unsigned char *)src);
+    return strcmp((char *)buf, want) == 0;
+}
+
+int main(void)
+{
+    unsigned char small[5];
+
+    printf("=== HTTPD string-safety tests ===\n");
+
+    /* ---- httpesc(): HTML escaping (S2) ---- */
+    CHECK(esc_is("abc", "abc"),                 "plain text is unchanged");
+    CHECK(esc_is("a<b", "a&lt;b"),              "'<' -> &lt;");
+    CHECK(esc_is("a>b", "a&gt;b"),              "'>' -> &gt;");
+    CHECK(esc_is("a&b", "a&amp;b"),             "'&' -> &amp;");
+    CHECK(esc_is("a\"b", "a&quot;b"),           "'\"' -> &quot;");
+    CHECK(esc_is("a'b", "a&#39;b"),             "'\\'' -> &#39;");
+    CHECK(esc_is("<>&\"'", "&lt;&gt;&amp;&quot;&#39;"),
+                                                "all five escape together");
+    CHECK(esc_is("\"><script>", "&quot;&gt;&lt;script&gt;"),
+                                                "an XSS breakout is neutralised");
+    CHECK(esc_is("", ""),                       "empty input -> empty output");
+
+    /* NULL source is treated as empty, never dereferenced */
+    httpesc(small, sizeof(small), NULL);
+    CHECK(small[0] == 0,                         "NULL source -> empty, no crash");
+
+    /* truncation is safe: never writes past the buffer, always terminated,
+       and never emits a partial entity */
+    httpesc(small, sizeof(small), (const unsigned char *)"aaaaaaaa");
+    CHECK(strlen((char *)small) < sizeof(small), "over-long plain input truncates safely");
+    httpesc(small, sizeof(small), (const unsigned char *)"<<<<");
+    CHECK(strcmp((char *)small, "&lt;") == 0,    "entity that fits is emitted whole");
+    httpesc(small, 4, (const unsigned char *)"<x");
+    CHECK(small[0] == 0,                          "entity that would overflow is dropped, not split");
+
+    /* ---- httpsrdr(): safe site-local redirect (S3) ---- */
+    CHECK(httpsrdr((const unsigned char *)"/") == 1,            "\"/\" is safe");
+    CHECK(httpsrdr((const unsigned char *)"/foo") == 1,         "\"/foo\" is safe");
+    CHECK(httpsrdr((const unsigned char *)"/a/b?x=1") == 1,     "path with query is safe");
+    CHECK(httpsrdr((const unsigned char *)"/login") == 1,       "\"/login\" is a safe path");
+
+    CHECK(httpsrdr(NULL) == 0,                                  "NULL is rejected");
+    CHECK(httpsrdr((const unsigned char *)"") == 0,             "empty is rejected");
+    CHECK(httpsrdr((const unsigned char *)"foo") == 0,          "no leading '/' is rejected");
+    CHECK(httpsrdr((const unsigned char *)"http://evil") == 0,  "absolute URL is rejected");
+    CHECK(httpsrdr((const unsigned char *)"//evil.com") == 0,   "'//host' (protocol-relative) is rejected");
+    CHECK(httpsrdr((const unsigned char *)"/\\evil.com") == 0,  "'/\\host' (backslash) is rejected");
+    CHECK(httpsrdr((const unsigned char *)"/a\r\nSet-Cookie: x") == 0,
+                                                                "CRLF (header injection) is rejected");
+    CHECK(httpsrdr((const unsigned char *)"/a\nb") == 0,        "bare LF is rejected");
+    CHECK(httpsrdr((const unsigned char *)"/a\rb") == 0,        "bare CR is rejected");
+
+    return mbt_test_summary("TSTSAFE");
+}


### PR DESCRIPTION
## What

Fixes **S2** (Critical) and **S3** (High) — the `httpcred.c` login/redirect path trusted the client-controlled `Sec-Uri` cookie (unauthenticated in the default config).

## S2 — cookie `sprintf` overflow + reflected XSS

`print_body()` did `sprintf(buf[512], body3[0]=..."value=\"%s\"", uri)` with `uri` = the `Sec-Uri` cookie (bounded only by the header limit, ~4000) → **stack overflow**, and reflected it **unescaped** into the login form → **XSS**.

**Fix:** new `http_html_escape()` (`src/httpesc.c`; escapes `& < > " '`, bounded, always NUL-terminated) + print the hidden field directly — the fixed `sprintf` buffer is gone.

## S3 — redirect over-read + `Location:` header injection / open redirect

`process_post()` did `strncpy(uribuf[256], buf, 256)` where `buf` is the **base64-decoded** cookie. `base64_decode` (`libc370 @@b64dec.c`) `calloc`s exactly `out_len` bytes and does **not** NUL-terminate — so `strncpy` **over-read the decoded allocation** hunting for a NUL, and the value then reached `Location:` with no CR/LF filter (**response splitting**) and no host check (**open redirect**).

**Fix:** copy exactly the reported decoded length (`memcpy` + terminate, not `strncpy`), then validate with new `http_safe_redirect()` (`src/httpsrdr.c`: require a single-leading-`/` site-local path; reject `//`, `/\` and CR/LF) before use, else fall back to `/`.

## Design

- The two helpers are plain externs (internal — **not** HTTPX-vectored) and are kept **free of `httpd.h`**, so the security-critical logic is unit-tested **DUAL** (host + MVS).
- base64 itself is a libc370 function — out of scope here; the httpd-side sanitiser is what's tested.

## Verification

- **`test/tstsafe.c` — 26 assertions, run natively (`make test-host`): all pass.** Covers HTML-escape (incl. a `"><script>` breakout, NULL source, safe truncation without splitting an entity) and the safe-redirect edge-case table (`/`, `/foo`, `/login`; reject `NULL`/empty/no-leading-`/`/`http://`/`//host`/`/\host`/CR/LF). This actually *executes* the gate, not just a compile.
- **cc370** compiles clean (exit 0): `httpesc.c`, `httpsrdr.c`, `httpcred.c`, `tstsafe.c`; generated CSECTs `HTTPESC`/`HTTPSRDR` match the `asm()` externs and `httpcred` references `=V(HTTPESC)`/`=V(HTTPSRDR)`.
- Full MVS run: `make test-mvs ARGS="--only TSTSAFE"` on the live system (also runs on host in `make check`).

## Docs

`docs/refactoring-backlog.md`: S2/S3 marked resolved, counts Security 11→9, order/table updated, `TSTSAFE` added to the Testing backlog (and the base64 note corrected to point at libc370).

Fixes #78
