### PR TITLE
Bound SSI output formatter with vsnprintf (S6)

### DIFF
--- a/docs/refactoring-backlog.md
+++ b/docs/refactoring-backlog.md
@@ -72,8 +72,8 @@ the *Also high-value* / hardening set below.
   clear win for static-request throughput (for CGI paths the LINK SVC, `P7`,
   dominates; profile before investing).
 
-**Counts (open/partial):** Security 8 · Memory & Stability 12 · Performance 7.
-*(2026-07-02: S1 PR #73; M1 PR #77; S2+S3 PR #79; S5 PR #81.)*
+**Counts (open/partial):** Security 7 · Memory & Stability 12 · Performance 7.
+*(2026-07-02: S1 PR #73; M1 PR #77; S2+S3 PR #79; S5 PR #81; S6 PR #83.)*
 
 ---
 
@@ -190,7 +190,13 @@ silently accepted. **Fix:** decode only inside the existing `if (str[1] &&
 str[2])` guard; optionally reject invalid escapes with 400.
 
 ### S6 — SSI output uses unbounded `vsprintf` into `buf[4096]`
-*Medium · Open · Effort XS · `httpfile.c:595,598` · was F-08 / audit M3*
+*Medium · Resolved (2026-07-02, PR #83 / issue #82) · Effort XS · `httpfile.c:595,598` · was F-08 / audit M3*
+
+> **Resolved:** `ssi_printv()` now uses `vsnprintf(buf, sizeof(buf), …)` and
+> clamps the would-be length to `sizeof(buf)-1` before `ssi_buffer()` copies it
+> (so an over-long SSI line — e.g. an attacker-controlled `HTTP_*` header echoed
+> by `ssi_printenv`/`ssi_echo` — truncates instead of overflowing the stack).
+> Mirrors the `http_printv()` pattern (`httpprtv.c:14-16`).
 
 ```c
 595  char buf[4096];
@@ -562,6 +568,7 @@ for frequently-called endpoints and enable mvsMF integration.
 | Cookie `sprintf` overflow + reflected XSS (S2) | **Resolved (2026-07-02)** | `http_html_escape()` + direct print — `httpcred.c`/`httpesc.c`, PR #79 / issue #78 |
 | `Sec-Uri` redirect over-read + header injection / open redirect (S3) | **Resolved (2026-07-02)** | length-bounded `memcpy` + `http_safe_redirect()` — `httpcred.c`/`httpsrdr.c`, PR #79 / issue #78 |
 | Percent-decoder OOB read on trailing `%` (S5) | **Resolved (2026-07-02)** | reads guarded by `str[1] && str[2]`; incomplete escape passed through — `httpdeco.c`, PR #81 / issue #80 |
+| Unbounded `vsprintf` in SSI `ssi_printv` (S6) | **Resolved (2026-07-02)** | `vsnprintf` + clamp — `httpfile.c`, PR #83 / issue #82 |
 
 ---
 
@@ -629,8 +636,8 @@ EBCDIC.
    broken both ways; only **M5** of that chain remains (see step 2).
 2. **Quick security wins:** ~~**S2**, **S3** (`httpcred` escape + CR/LF
    reject)~~ **✔ done (PR #79)**; ~~**S5** (percent-decoder OOB)~~ **✔ done
-   (PR #81)**; remaining: **S6** (`vsnprintf`), **M3** (unlock/free swap),
-   **M4**, **M5** (one-line robustness). Mostly XS.
+   (PR #81)**; ~~**S6** (`vsnprintf`)~~ **✔ done (PR #83)**; remaining: **M3**
+   (unlock/free swap), **M4**, **M5** (one-line robustness). Mostly XS.
 3. **Memory stability:** **M2** (credential reaper — also closes the
    session-timeout security gap), **M8**/**M9**/**M10** (env/CGI alloc hygiene).
 4. **Performance:** **P1** (env-lookup index — biggest CPU win), then **P2**/**P3**
@@ -692,3 +699,8 @@ natively (26/26). PR #79, issue #78. Counts Security 11→9.
 str[2])` guard (`&&` short-circuits, so `str[2]` is never read past the NUL);
 incomplete escapes are passed through literally. `TSTDECO`'s trailing-`%`
 assertion updated to the new contract. PR #81, issue #80. Counts Security 9→8.
+
+**2026-07-02:** **S6** (unbounded `vsprintf` in SSI `ssi_printv`) fixed in
+`httpfile.c` — `vsnprintf(buf, sizeof(buf), …)` + clamp the would-be length to
+`sizeof(buf)-1` before `ssi_buffer()`, mirroring `http_printv()`. PR #83,
+issue #82. Counts Security 8→7.

--- a/src/httpfile.c
+++ b/src/httpfile.c
@@ -594,8 +594,14 @@ ssi_printv(HTTPC *httpc, const char *fmt, va_list args)
     int     len;
     char	buf[4096];
 
-	/* Okay here we go. Format the string into the buffer */
-    len = vsprintf(buf, fmt, args);
+	/* Okay here we go. Format the string into the buffer.  vsnprintf (not
+	   vsprintf): an SSI line built from an over-long env value -- e.g. an
+	   attacker-controlled HTTP_* header echoed by ssi_printenv/ssi_echo --
+	   could exceed buf[].  vsnprintf returns the would-be length, so clamp it
+	   before ssi_buffer() copies it (mirrors http_printv() in httpprtv.c). */
+    len = vsnprintf(buf, sizeof(buf), fmt, args);
+    if (len >= (int)sizeof(buf))
+        len = sizeof(buf) - 1;
     if (len < 0) {
 		wtof("%s: looks like a bug to me, len=%d, httpc->len=%d", 
 			__func__, len, httpc->len);


### PR DESCRIPTION
## What

Fixes **S6**: the SSI output formatter `ssi_printv()` (`src/httpfile.c`) used unbounded `vsprintf` into a fixed `char buf[4096]`.

## Why

```c
char buf[4096];
len = vsprintf(buf, fmt, args);   /* not vsnprintf */
...
ssi_buffer(httpc, buf, len);
```

Every `ssi_printf()` funnels through this. `ssi_printenv()` emits a table row per env var — including attacker-controlled `HTTP_*` request headers (bounded only by ~4000) — and `ssi_echo()` echoes an env value; either can format a line longer than 4096 → **stack buffer overflow**. Requires SSI enabled on a served document.

## Change

```c
len = vsnprintf(buf, sizeof(buf), fmt, args);
if (len >= (int)sizeof(buf))
    len = sizeof(buf) - 1;
```

`vsnprintf` returns the *would-be* length, which must be clamped before `ssi_buffer()` copies `len` bytes (otherwise it over-reads `buf`). This mirrors the proven `http_printv()` pattern (`httpprtv.c:14-16`, the CRIT#2 resolution). XS, no ABI change.

## Verification

- **cc370** compiles clean (exit 0); the generated ASM now references `=V(VSNPRINT)` (no more `vsprintf`).
- Not unit-testable in isolation (a static function in the SSI pipeline, driven through an HTTPC + the SSI buffer machinery); the fix mirrors an existing, proven pattern. Behavioural check on the live system: serve an SSI document that echoes an over-long variable — it truncates instead of abending the worker.

## Docs

`docs/refactoring-backlog.md`: S6 marked resolved, counts Security 8→7, order/table updated.

Fixes #82
