### PR TITLE
Enforce Content-Length on the POST body (S7)

### DIFF
--- a/docs/refactoring-backlog.md
+++ b/docs/refactoring-backlog.md
@@ -71,8 +71,8 @@ transient error, PR #85).
   clear win for static-request throughput (for CGI paths the LINK SVC, `P7`,
   dominates; profile before investing).
 
-**Counts (open/partial):** Security 6 · Memory & Stability 6 · Performance 7.
-*(2026-07-02: S1 #73; M1 #77; S2+S3 #79; S5 #81; S6 #83; M3+M4+M5 #85; M8+M9+M10 #87; S4 was already mitigated — finding corrected, no code.)*
+**Counts (open/partial):** Security 5 · Memory & Stability 6 · Performance 7.
+*(2026-07-02: S1 #73; M1 #77; S2+S3 #79; S5 #81; S6 #83; M3+M4+M5 #85; M8+M9+M10 #87; S4 already mitigated — corrected. 2026-07-03: S7 #89.)*
 
 ---
 
@@ -213,16 +213,24 @@ env var — including attacker-controlled `HTTP_*` headers (~4000 bytes) — and
 **Fix:** `vsnprintf(buf, sizeof(buf), fmt, args)` + handle truncation.
 
 ### S7 — POST/PUT body: no `Content-Length` enforcement (413)
-*Medium · Partial · Effort S · `httppars.c:140-215` · was F-09 / MED#9(2026-03)*
+*Medium · Resolved (2026-07-03, PR #89 / issue #88) · Effort S · `httppars.c:140-215` · was F-09 / MED#9(2026-03)*
 
-The keep-alive **poisoning** half is now mitigated: when a body was present but
-not fully read, keep-alive is disabled (`httppars.c:206-210`,
-`HTTP_CONTENT-LENGTH`/`HTTP_TRANSFER-ENCODING` ⇒ `keepalive = 0`). **Residual:**
-the body is still read with a blanket `recv(buf, CBUFSIZE-1)` with no
-`Content-Length` parse, no `413 Payload Too Large` for oversize bodies, and no
-rejection of a missing `Content-Length` (RFC 7230 §3.3.3).
-**Fix:** parse `Content-Length`, read exactly that many bytes, 413 on oversize,
-reject missing CL on a body-bearing method.
+The keep-alive **poisoning** half was already mitigated (`keepalive=0` on an
+unread body). The residual was: a blanket `recv(buf, CBUFSIZE-1)` with no
+`Content-Length` parse, no `413`, and mishandling of a missing CL.
+
+> **Resolved:** a new pure classifier `httpbody()` (`src/httpbody.c`, RFC 7230
+> §3.3.3) maps `(Content-Length, Transfer-Encoding?) → {NONE, READ(n),
+> TOO_LARGE, BAD}`. `httppars` now: **413** on an oversize CL (added the missing
+> `413 Payload Too Large` to `http_resp`, ref TSK-110), **400** on a malformed
+> CL, treats a missing CL / no TE as a **zero-length body** (RFC rule 6 — fixes
+> the old blanket-`recv` → `EWOULDBLOCK` → RESET on a bodyless POST), and caps
+> the single non-blocking `recv` at the declared length. Classifier dual-tested
+> (`TSTBODY`, 16 assertions, run natively). **Deliberately out of scope** (kept
+> tight): no "read exactly CL" loop (on a non-blocking socket that is itself a
+> slowloris — needs `select`+`CLIENT_TIMEOUT`, see `P2`), no chunked
+> request-body decode, no POST keep-alive enablement. **PUT** bodies are left
+> for the CGI to read (`httppars.c:113-118`) — unchanged.
 
 ### S8 — No limit on query/POST parameter count (memory-exhaustion DoS)
 *Medium · Open · Effort XS · `httppars.c` query/POST loops · was F-12 / MED#11*
@@ -610,6 +618,7 @@ for frequently-called endpoints and enable mvsMF integration.
 | Env-block ~4 B/var over-allocation (M9) | **Resolved (2026-07-02)** | `offsetof`-based sizing + `TSTNENV` — `httpnenv.c`, PR #87 / issue #86 |
 | Unchecked `strdup`/`array_add` in CGI registration (M10) | **Resolved (2026-07-02)** | free partial entry on failure — `httpacgi.c`, PR #87 / issue #86 |
 | SSI path traversal (S4) | **Already mitigated** — finding corrected (no code) | `http_open` rejects `..` (`httpopen.c:17`, `0c171fe`) + prepends DOCROOT (`:50`, `1c2ad3c`) |
+| POST body `Content-Length` enforcement (S7) | **Resolved (2026-07-03)** | `httpbody()` classifier: 413/400/zero-body + recv capped at CL + `TSTBODY` — `httppars.c`/`httpbody.c`, PR #89 / issue #88 |
 
 ---
 
@@ -639,6 +648,10 @@ EBCDIC.
 - `TSTNENV` — `http_new_env()`/`httpnenv()` env-block allocation + layout,
   guarding the **M9** `offsetof` sizing (name/value round-trip). MVS-target.
   *(PR #87 / issue #86.)*
+- `TSTBODY` — `httpbody()` request-body length classifier (**S7**, RFC 7230
+  §3.3.3). **Dual** (host + MVS); 16 assertions over the decision table
+  (absent/zero/valid/oversize/negative/junk/OWS/`Transfer-Encoding`).
+  *(PR #89 / issue #88.)*
 
 **Open — pure helpers, cleanly unit-testable (good next targets)**
 - **`httpcmp`/`httpcmpn`** — EBCDIC caseless compare (collation correctness; XS).
@@ -684,8 +697,8 @@ EBCDIC.
    session-timeout security gap).
 4. **Performance:** **P1** (env-lookup index — biggest CPU win), then **P2**/**P3**
    (one send-state machine), **P4**.
-5. **Hardening:** ~~**S4**~~ (already mitigated — finding corrected), **S7**,
-   **S8**, **S9–S12**, **M6**/**M7**/**M11**/**M12**.
+5. **Hardening:** ~~**S4**~~ (already mitigated — finding corrected), ~~**S7**~~
+   **✔ (PR #89)**, **S8**, **S9–S12**, **M6**/**M7**/**M11**/**M12**.
    **M13** (shutdown teardown race) is mostly a **libc370** fix — tracked in
    mvslovers/libc370#6; it affects every cthread user, not just HTTPD.
 6. **Architecture:** router/middleware, HTTPX auth helper, error enum, file
@@ -773,3 +786,12 @@ predating the consolidation. The finding traced the caller but missed the
 callee's guard. No code change (a redundant `ssi_include` reject would be
 defensive noise). Backlog corrected; Security count 7→6. Filed the separate
 `DOCROOT`-unset confinement gap under *Security architecture*.
+
+**2026-07-03:** **S7** (POST body `Content-Length` enforcement) fixed in
+`httppars.c` — new pure `httpbody()` classifier (`src/httpbody.c`, RFC 7230
+§3.3.3): **413** on oversize CL (added the missing `413` to `http_resp`, ref
+TSK-110), **400** on malformed CL, **zero-length body** on missing CL/no TE
+(fixes the old blanket-`recv`→RESET on a bodyless POST), and the `recv` is
+capped at the declared length. Scope kept tight (no exact-CL loop = slowloris
+risk, no chunked decode, no POST keep-alive). Dual `TSTBODY` (16, run
+natively). PR #89, issue #88. Counts Security 6→5.

--- a/include/httpbody.h
+++ b/include/httpbody.h
@@ -1,0 +1,30 @@
+/* HTTPBODY.H
+** Classify a request message body length (RFC 7230 §3.3.3).
+**
+** Free of httpd.h so the pure classification logic unit-tests on the host as
+** well as on MVS (see test/tstbody.c).
+*/
+#ifndef HTTPBODY_H
+#define HTTPBODY_H
+
+/* classification of an incoming request body */
+enum {
+    HTTP_BODY_NONE = 0,     /* no body to read (no CL & no TE, CL 0, or a
+                               Transfer-Encoding body we do not decode here)   */
+    HTTP_BODY_READ,         /* read *len bytes                                 */
+    HTTP_BODY_TOO_LARGE,    /* Content-Length exceeds max -> 413               */
+    HTTP_BODY_BAD           /* malformed Content-Length -> 400                 */
+};
+
+/* Classify the request body from the Content-Length header value (cl, NULL or
+** empty when absent), whether a Transfer-Encoding header is present, and the
+** maximum number of bytes the server will buffer (max).  On HTTP_BODY_READ
+** *len is set to the byte count (1..max); it is 0 otherwise.
+**
+** RFC 7230 §3.3.3: a Transfer-Encoding means the length is framed elsewhere
+** (we do not decode it -> NONE); with neither header a request body length is
+** 0 (-> NONE); a Content-Length must be a non-negative decimal integer.
+*/
+int httpbody(const unsigned char *cl, int te_present, long max, long *len);
+
+#endif /* HTTPBODY_H */

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -44,6 +44,7 @@
 #include "types.h"                  /* UCHAR, USHRT, UINT, ULONG    */
 #include "cred.h"					/* Credentials					*/
 #include "httpxlat.h"               /* ASCII/EBCDIC translation     */
+#include "httpbody.h"               /* request body classification  */
 
 /* httpluax.h removed — HTTPLUA is now a separate project (mvslovers/httplua) */
 

--- a/project.toml
+++ b/project.toml
@@ -95,6 +95,12 @@ host = false            # httpd.h -> crent370 internals -> MVS-only (test-mvs)
 name = "TSTSAFE"
 sources = ["test/tstsafe.c", "src/httpesc.c", "src/httpsrdr.c"]
 
+# httpbody() request-body length classifier (S7 Content-Length enforcement).
+# Free of httpd.h -> DUAL (host + MVS); helper source listed for the host link.
+[[test]]
+name = "TSTBODY"
+sources = ["test/tstbody.c", "src/httpbody.c"]
+
 # http_new_env() / httpnenv() env-block allocation + layout (guards the M9
 # offsetof sizing).  Needs the HTTPV struct via httpd.h, so MVS-only; httpnenv
 # (HTTPNENV) resolves from the [internal] autocall archive.

--- a/src/httpbody.c
+++ b/src/httpbody.c
@@ -1,0 +1,44 @@
+/* HTTPBODY.C
+** Classify a request message body length (RFC 7230 §3.3.3).
+**
+** Kept free of httpd.h (char literals only) so the RFC decision table
+** unit-tests dual (host + MVS).  Digits '0'..'9' are contiguous in both EBCDIC
+** and ASCII, so the parse is correct under either encoding.
+*/
+#include "httpbody.h"
+
+int
+httpbody(const unsigned char *cl, int te_present, long max, long *len)
+{
+    long        v = 0;
+
+    if (len) *len = 0;
+
+    /* Transfer-Encoding present: the body is framed elsewhere (e.g. chunked),
+       not by Content-Length.  We do not decode it here -> read nothing. */
+    if (te_present) return HTTP_BODY_NONE;
+
+    /* No Content-Length and no Transfer-Encoding -> body length is 0. */
+    if (!cl || !*cl) return HTTP_BODY_NONE;
+
+    /* optional leading whitespace (in case the header parser did not trim) */
+    while (*cl == ' ' || *cl == '\t') cl++;
+
+    /* require at least one decimal digit */
+    if (*cl < '0' || *cl > '9') return HTTP_BODY_BAD;
+
+    for (; *cl >= '0' && *cl <= '9'; cl++) {
+        if (v > max) return HTTP_BODY_TOO_LARGE;    /* before *10: no overflow */
+        v = v * 10 + (*cl - '0');
+    }
+    if (v > max) return HTTP_BODY_TOO_LARGE;
+
+    /* optional trailing whitespace, then nothing else (no sign, no junk) */
+    while (*cl == ' ' || *cl == '\t') cl++;
+    if (*cl) return HTTP_BODY_BAD;
+
+    if (v == 0) return HTTP_BODY_NONE;
+
+    if (len) *len = v;
+    return HTTP_BODY_READ;
+}

--- a/src/httppars.c
+++ b/src/httppars.c
@@ -138,6 +138,43 @@ failed:
     goto quit;
 
 postdata:
+    /* classify the request body (RFC 7230 §3.3.3) before reading it */
+    {
+        const UCHAR *cl = http_get_env(httpc, "HTTP_CONTENT-LENGTH");
+        int          te = (http_get_env(httpc, "HTTP_TRANSFER-ENCODING") != NULL);
+        long         clen = 0;
+
+        switch (httpbody(cl, te, CBUFSIZE-1, &clen)) {
+        case HTTP_BODY_TOO_LARGE:
+            /* body larger than we buffer: reject, leave it unread, close */
+            httpc->keepalive = 0;
+            http_resp(httpc, 413);
+            http_printf(httpc, "Cache-Control: no-store\r\n");
+            http_printf(httpc, "Content-Type: text/plain\r\n");
+            http_printf(httpc, "\r\n");
+            http_printf(httpc, "413 Payload Too Large\n");
+            httpc->state = CSTATE_DONE;
+            goto quit;
+        case HTTP_BODY_BAD:
+            /* malformed Content-Length */
+            httpc->keepalive = 0;
+            http_resp(httpc, 400);
+            http_printf(httpc, "Cache-Control: no-store\r\n");
+            http_printf(httpc, "Content-Type: text/plain\r\n");
+            http_printf(httpc, "\r\n");
+            http_printf(httpc, "400 Bad Request\n");
+            httpc->state = CSTATE_DONE;
+            goto quit;
+        case HTTP_BODY_NONE:
+            /* no body to read (no CL & no TE, CL 0, or a chunked body we do
+               not decode here) -- don't block on a recv that won't complete */
+            goto nodata;
+        default:                    /* HTTP_BODY_READ */
+            datalen = (int)clen;    /* bytes to read (1..CBUFSIZE-1) */
+            break;
+        }
+    }
+
     /* what type of POST data do we have */
     p = http_get_env(httpc, "HTTP_CONTENT-TYPE");
     if (!p) goto nodata;
@@ -147,10 +184,12 @@ postdata:
     /* if not form data then leav it alone */
     if (http_cmp(p, "application/x-www-form-urlencoded")!=0) goto postother;
 
-    /* retrieve the form data and decode into "POST_..." variables */
+    /* retrieve the form data and decode into "POST_..." variables.  Read at
+       most the declared Content-Length so we never slurp bytes belonging to a
+       pipelined next request (single non-blocking recv -- see S7 scope). */
     memset(httpc->buf, 0, CBUFSIZE);
     buf = httpc->buf;
-    len = CBUFSIZE-1;
+    len = datalen;
     rc = recv(httpc->socket, buf, len, 0);
     if (rc < 0) goto failed;
     
@@ -185,10 +224,10 @@ postdata:
     goto nodata;
 
 postother:
-    /* some other POST data to be received */
+    /* some other POST data to be received -- read at most Content-Length */
     memset(httpc->buf, 0, CBUFSIZE);
     buf = httpc->buf;
-    len = CBUFSIZE-1;
+    len = datalen;
     rc = recv(httpc->socket, buf, len, 0);
     if (rc < 0) goto failed;
     

--- a/src/httpresp.c
+++ b/src/httpresp.c
@@ -35,6 +35,7 @@ httpresp(HTTPC *httpc, int resp)
     case 404: p = "404 Not Found";              break;
     case 405: p = "405 Method Not Allowed";     break;
     case 409: p = "409 Conflict";               break;
+    case 413: p = "413 Payload Too Large";      break;
     case 414: p = "414 URI Too Long";           break;
     case 500: p = "500 Internal Server Error";  break;
     case 507: p = "507 Insufficient Storage";   break;

--- a/test/tstbody.c
+++ b/test/tstbody.c
@@ -1,0 +1,63 @@
+/* TSTBODY.C
+** Tests for httpbody() -- the request-body length classifier (src/httpbody.c,
+** RFC 7230 §3.3.3) used by S7's Content-Length enforcement.
+**
+** httpbody() is free of httpd.h, so this is a DUAL test: it runs natively via
+** `make test-host` (real execution of the decision table) and on MVS via
+** `make test-mvs`.
+*/
+#include <stdio.h>
+#include "httpbody.h"
+#include <mbtcheck.h>
+
+/* classify a Content-Length string; returns the code and sets *n */
+static int cls(const char *cl, int te, long max, long *n)
+{
+    *n = -1;
+    return httpbody((const unsigned char *)cl, te, max, n);
+}
+
+int main(void)
+{
+    long n;
+
+    printf("=== HTTPD httpbody (Content-Length) tests ===\n");
+
+    /* no body: absent CL, empty CL, or CL == 0 */
+    CHECK(cls(NULL, 0, 3999, &n) == HTTP_BODY_NONE && n == 0,
+          "absent Content-Length -> no body (RFC 3.3.3)");
+    CHECK(cls("", 0, 3999, &n) == HTTP_BODY_NONE, "empty Content-Length -> no body");
+    CHECK(cls("0", 0, 3999, &n) == HTTP_BODY_NONE, "Content-Length 0 -> no body");
+
+    /* read: a valid length within the cap */
+    CHECK(cls("100", 0, 3999, &n) == HTTP_BODY_READ && n == 100,
+          "\"100\" -> read 100 bytes");
+    CHECK(cls("3999", 0, 3999, &n) == HTTP_BODY_READ && n == 3999,
+          "length exactly at the cap -> read");
+    CHECK(cls("50", 0, 50, &n) == HTTP_BODY_READ && n == 50,
+          "cap boundary honoured for a smaller max");
+
+    /* too large: over the cap, and a huge value must not overflow */
+    CHECK(cls("4000", 0, 3999, &n) == HTTP_BODY_TOO_LARGE, "one over the cap -> 413");
+    CHECK(cls("100", 0, 50, &n) == HTTP_BODY_TOO_LARGE, "over a smaller cap -> 413");
+    CHECK(cls("99999999999999999999", 0, 3999, &n) == HTTP_BODY_TOO_LARGE,
+          "huge Content-Length -> 413, no overflow");
+
+    /* bad: sign, non-numeric, trailing junk */
+    CHECK(cls("-5", 0, 3999, &n) == HTTP_BODY_BAD, "negative -> 400");
+    CHECK(cls("abc", 0, 3999, &n) == HTTP_BODY_BAD, "non-numeric -> 400");
+    CHECK(cls("12abc", 0, 3999, &n) == HTTP_BODY_BAD, "trailing junk -> 400");
+    CHECK(cls("+7", 0, 3999, &n) == HTTP_BODY_BAD, "leading '+' -> 400");
+
+    /* surrounding whitespace is tolerated (in case the header wasn't trimmed) */
+    CHECK(cls(" 100 ", 0, 3999, &n) == HTTP_BODY_READ && n == 100,
+          "leading/trailing OWS tolerated");
+
+    /* Transfer-Encoding present -> framed elsewhere, don't read as CL body */
+    CHECK(cls("100", 1, 3999, &n) == HTTP_BODY_NONE,
+          "Transfer-Encoding present -> not a Content-Length body");
+    CHECK(cls(NULL, 1, 3999, &n) == HTTP_BODY_NONE,
+          "Transfer-Encoding present, no CL -> none");
+
+    return mbt_test_summary("TSTBODY");
+}


### PR DESCRIPTION
## What

Fixes **S7**: enforce `Content-Length` on the POST body — 413 on oversize, 400 on malformed, correct zero-body handling — instead of a blanket `recv`.

## Why

`httppars` read the POST body with `recv(buf, CBUFSIZE-1)`: no `Content-Length` parse, no **413** for an oversize body, and a bodyless POST (no CL, no `Transfer-Encoding`) hit the blanket `recv` → `EWOULDBLOCK` → `goto failed` → RESET.

## Change

New pure classifier **`httpbody()`** (`src/httpbody.c`, RFC 7230 §3.3.3): `(Content-Length, Transfer-Encoding?) → {NONE, READ(n), TOO_LARGE, BAD}`. `httppars` drives from it:
- **413 Payload Too Large** when CL exceeds what we buffer (`CBUFSIZE-1`) — added the missing `413` to `http_resp` (ref TSK-110).
- **400 Bad Request** on a malformed CL (sign/non-numeric/trailing junk).
- **zero-length body** on a missing CL with no `Transfer-Encoding` (RFC rule 6) → skip the `recv` instead of blocking.
- the single non-blocking `recv` is **capped at the declared length** so it can't slurp a pipelined next request.

## Deliberately out of scope (kept tight, per review)

- **No "read exactly CL" loop** — on a non-blocking socket that is itself a slowloris DoS (client dribbles bytes, worker waits). A bounded-time exact read needs `select` + `CLIENT_TIMEOUT` — that's `P2` (the httprexx/send-path lane). The multi-segment short-read is a pre-existing, server-wide limitation, unchanged.
- **No chunked request-body decode** (already keepalive-disabled at `httppars.c:208-210`; 501 deferred).
- **No POST keep-alive enablement** (stays conservative).
- **PUT** bodies are intentionally left for the CGI to read (`httppars.c:113-118`) — S7 is POST-only.

## Verification

- **`test/tstbody.c` — 16 assertions, run natively (`make test-host`): all pass.** Decision table: absent / empty / `0` / valid / at-cap / oversize / huge (no overflow) / negative / non-numeric / trailing-junk / `+7` / OWS / `Transfer-Encoding` present. `httpbody()` is `httpd.h`-free → dual (host + MVS).
- **cc370** compiles clean: `httpbody.c`, `httppars.c`, `httpresp.c` (CSECT `HTTPBODY` resolves via autocall).
- Live checks (`make test-mvs`, or curl): a POST with `Content-Length: 999999` → **413**; `Content-Length: abc` → **400**; a POST with no body → completes (no RESET); a normal form POST still parses `POST_*`.

## Docs

`docs/refactoring-backlog.md`: S7 resolved, Security count 6→5, `TSTBODY` added to the Testing backlog, order/table/provenance updated.

Fixes #88
