### PR TITLE
Credential reaper / session timeout (M2)

### DIFF
--- a/credentials/include/cred.h
+++ b/credentials/include/cred.h
@@ -128,8 +128,19 @@ extern CRED *cred_find_by_acee(ACEE *acee)													asm("CREDFBAC");
  * returns NULL on error, check console for errors.
  * cred was added to WSA cred array if not NULL.
  */
-extern CRED * 
+extern CRED *
 cred_login(unsigned addr, unsigned char *userid, unsigned char *password)					asm("CREDLIN");
+
+/* overflow cap on the credential array (login flood protection, M2) */
+#define CRED_MAX 256
+
+/* cred_reap() - free CREDs (and their ACEEs) idle longer than ttl_secs.
+ * ttl_secs == 0 disables reaping. Returns the number reaped. */
+extern unsigned cred_reap(unsigned ttl_secs)												asm("CREDREAP");
+
+/* credexp() - pure expiry decision: has a credential idle for elapsed_secs
+ * exceeded ttl_secs? (ttl 0 -> never; negative elapsed -> not yet; '>' bound) */
+extern int credexp(long elapsed_secs, unsigned ttl_secs)									asm("CREDEXP");
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
 /* The following function prototypes are used internally.                             */

--- a/credentials/src/credexp.c
+++ b/credentials/src/credexp.c
@@ -1,0 +1,17 @@
+/* CREDEXP.C
+** Expiry decision for the credential reaper (M2): given how many seconds a
+** credential has been idle and the configured TTL, has it expired?
+**
+** Kept free of project headers (plain integers only) so the boundary logic
+** unit-tests on the host as well as on MVS (see test/tstexpire.c).  The C name
+** is <= 8 chars, so cc370 maps it to CSECT CREDEXP.
+*/
+
+int
+credexp(long elapsed_secs, unsigned ttl_secs)
+{
+    if (ttl_secs == 0)    return 0;     /* reaping disabled -> never expires   */
+    if (elapsed_secs < 0) return 0;     /* clock skew (last > now) -> not yet  */
+
+    return elapsed_secs > (long) ttl_secs;   /* strict: exactly at TTL is live */
+}

--- a/credentials/src/credfbtk.c
+++ b/credentials/src/credfbtk.c
@@ -26,7 +26,13 @@ CRED *cred_find_by_token(CREDTOK *token)
 			break;
 		}
 	}
-	
+
+	/* refresh the last-used stamp so activity keeps the session alive past the
+	   reaper's TTL (M2).  Written under LOCK_SHR -- a torn 8-byte write between
+	   near-simultaneous readers is benign (all write ~now); the reaper reads it
+	   under LOCK_EXC after these readers drain. */
+	if (found) found->last = time64(NULL);
+
 	if (lockrc==0) unlock(array, LOCK_SHR);
 	
 quit:

--- a/credentials/src/credlin.c
+++ b/credentials/src/credlin.c
@@ -1,6 +1,8 @@
 #include "cred.h"
 
-CRED * 
+#undef array_count
+
+CRED *
 cred_login(unsigned addr, unsigned char *userid, unsigned char *password)
 {
 	CRED	***array= cred_array();
@@ -76,6 +78,15 @@ cred_login(unsigned addr, unsigned char *userid, unsigned char *password)
 	if (!cred) {
 		wtof("%s: cred_new() failed", __func__);
 		racf_logout(&acee);
+		goto cleanup;
+	}
+
+	/* overflow protection (M2): reject the new session when the array is full
+	   rather than evict a live one (login flood).  cred_free() logs the ACEE
+	   back out and NULLs cred, so cred_login() returns NULL. */
+	if (array_count(array) >= CRED_MAX) {
+		wtof("%s: credential array full (%u); login rejected", __func__, CRED_MAX);
+		cred_free(&cred);
 		goto cleanup;
 	}
 

--- a/credentials/src/credreap.c
+++ b/credentials/src/credreap.c
@@ -1,0 +1,55 @@
+/* CREDREAP.C
+** Reap idle credentials (M2): remove and free CREDs (and their RACF ACEEs)
+** that have been idle longer than the TTL.  cred->last is refreshed on every
+** cred_find_by_token() hit, so an actively used session is never reaped (given
+** SESSION_TIMEOUT >> the longest request; see the M2 note in the backlog).
+*/
+#include "cred.h"
+
+#undef array_count
+
+unsigned cred_reap(unsigned ttl_secs)
+{
+    CRED     ***array = cred_array();
+    CRED     *dead[CRED_MAX];
+    unsigned ndead = 0;
+    unsigned n;
+    unsigned i;
+    int      lockrc;
+    time64_t now;
+
+    if (!array)        return 0;
+    if (ttl_secs == 0) return 0;        /* reaping disabled */
+
+    now = time64(NULL);
+
+    lockrc = lock(array, LOCK_EXC);
+
+    /* iterate from the tail so array_del() index shifts don't skip entries */
+    for (n = array_count(array); n >= 1; n--) {
+        CRED *c = array_get(array, n);
+
+        if (!c) continue;
+        if (strcmp(c->eye, CRED_EYE)) continue;
+        if (!credexp((long) difftime64(now, c->last), ttl_secs)) continue;
+
+        /* skip anything a concurrent path is already freeing */
+        if (testlock(c, LOCK_EXC) == 4) continue;
+
+        /* unlink now; free (which does the RACF logout) AFTER releasing the
+           array lock so a mass expiry doesn't stall workers in
+           cred_find_by_token() */
+        array_del(array, n);
+        if (ndead < CRED_MAX) dead[ndead++] = c;
+    }
+
+    if (lockrc == 0) unlock(array, LOCK_EXC);
+
+    /* the reaped CREDs are unlinked -> unreachable via cred_find_*(); free */
+    for (i = 0; i < ndead; i++) {
+        CRED *c = dead[i];
+        cred_free(&c);
+    }
+
+    return ndead;
+}

--- a/docs/refactoring-backlog.md
+++ b/docs/refactoring-backlog.md
@@ -71,8 +71,8 @@ transient error, PR #85).
   clear win for static-request throughput (for CGI paths the LINK SVC, `P7`,
   dominates; profile before investing).
 
-**Counts (open/partial):** Security 1 · Memory & Stability 4 · Performance 7.
-*(2026-07-02: S1 #73; M1 #77; S2+S3 #79; S5 #81; S6 #83; M3+M4+M5 #85; M8+M9+M10 #87; S4 already mitigated — corrected. 2026-07-03: S7 #89; S8 #91; S9+S10+S12+M6+M11 #93.)* Remaining Security: **S11** (deferred).
+**Counts (open/partial):** Security 1 · Memory & Stability 3 · Performance 7.
+*(2026-07-02: S1 #73; M1 #77; S2+S3 #79; S5 #81; S6 #83; M3+M4+M5 #85; M8+M9+M10 #87; S4 already mitigated — corrected. 2026-07-03: S7 #89; S8 #91; S9+S10+S12+M6+M11 #93; M2 #95.)* Remaining: Security **S11** (deferred); M&S = **M7/M12** (latent) + **M13** (libc370).
 
 ---
 
@@ -289,8 +289,9 @@ the parse buffer, so the original NULL-deref was not reachable.
 *From the 2026-03 review §Security Architecture — still valid:*
 - **No TLS** — login credentials are sent in plaintext POST.
 - **No `HttpOnly`/`Secure`/`SameSite`** on the `Sec-Token` cookie.
-- **No session timeout / token expiry** — see `M2` (no reaper); fixing `M2`
-  delivers this.
+- ~~**No session timeout / token expiry**~~ **✔ delivered by `M2`** (PR #95):
+  idle CRED+ACEE reaper with a Parmlib `SESSION_TIMEOUT`. Token *expiry* (a hard
+  max-age independent of activity) is still open if wanted.
 - **No login rate-limiting** — brute force possible.
 - **Blowfish** (64-bit block) for in-memory CREDID — adequate for transient
   storage, dated as a standard.
@@ -301,6 +302,13 @@ the parse buffer, so the original NULL-deref was not reachable.
   UFS root — bounded to the UFS namespace but not to a subtree. Not the SSI
   traversal (S4), but a config-hardening gap: consider requiring `DOCROOT` (or
   defaulting to a safe subtree) rather than serving the UFS root.
+- **Credential-package unification (needs joint analysis).** HTTPD's credential
+  subsystem (`credentials/` — the AS-wide `cred_array()`, `cred_login`/`_find`/
+  `_free`/`_reap`, CRED+ACEE) and **mvsMF's own authentication** are currently
+  **two separate auth tracks**; the maintainer wants a single model backing both
+  (mvsMF presently rolls its own). Before deeper credential work, analyse and
+  discuss the whole package jointly (httpd + mvsMF) to converge on one track.
+  Ties to the HTTPX `http_check_auth` helper idea under *Architecture*.
 
 ---
 
@@ -342,17 +350,32 @@ already used at `httpd.c:903` and in mvsMF's `router.c`); on non-zero rc run
 for the dump. This also contains S9b and the other core derefs.
 
 ### M2 — Credential array has no reaper → unbounded CRED + ACEE growth
-*Medium · Open · Effort M · `credentials/src/crednew.c:10` · audit M1 (= security session-timeout)*
+*Medium · Resolved (2026-07-03, PR #95 / issue #94) · Effort M · `credentials/src/crednew.c:10` · audit M1 (= security session-timeout)*
 
-`cred->last = time64(NULL)` is written once and **never read** (verified: no
-reader in `src/` or `credentials/src/`); there is no idle-expiry, reaper, or
-reconfig. A `CRED` (≈80 B) + a RACF ACEE is added per distinct
-`(addr,user,pass)` login and removed only by an explicit `/logout` with the
-exact `Sec-Token`, or at shutdown. A client that never logs out, or re-logs-in,
-leaves the prior CRED+ACEE resident forever.
-**Fix:** refresh `cred->last` on each `cred_find_by_token` hit; add a periodic
-sweep that `array_del`+`cred_free`s entries idle beyond a configurable TTL (this
-*is* the missing session timeout); or cap the array.
+`cred->last = time64(NULL)` was written once and never read; a `CRED` (≈80 B) +
+RACF ACEE per login was removed only by explicit `/logout` or shutdown.
+
+> **Resolved — this is the session timeout.**
+> - **Refresh:** `cred_find_by_token()` (the only per-request lookup — verified;
+>   `by_id`/`by_acee` unused) stamps `cred->last = time64(NULL)` on every hit.
+> - **Reaper:** `cred_reap(ttl_secs)` (`credreap.c`) walks the WSA array under
+>   `LOCK_EXC`, `array_del`s entries idle > TTL (skipping any `testlock` shows
+>   in-use), and `cred_free`s them (RACF logout) **after releasing** the array
+>   lock. The decision is a pure `credexp(elapsed,ttl)` helper — dual-tested
+>   (`TSTEXPIRE`).
+> - **Sweep** runs in the `socket_thread` select loop, throttled ~60 s — **no
+>   new thread** (`cred_array()` is AS-wide, so the socket_thread sees the
+>   workers' creds).
+> - **Config** `SESSION_TIMEOUT <min>` (Parmlib, default 30, `0`=off →
+>   `httpd->cfg_session_timeout`, reusing padding). `httpprm` warns if it is
+>   `<= CLIENT_TIMEOUT`.
+> - **Cap** in `cred_login()`: reject a new login when the array is full
+>   (`CRED_MAX` 256) — no eviction of a live session.
+> - **UAF note (honest):** the guard is refresh-at-lookup **+ the invariant
+>   `SESSION_TIMEOUT` >> longest request** (`CLIENT_TIMEOUT` and worst-case CGI
+>   runtime); `testlock` catches a concurrent *free*, not a borrow. A request
+>   outliving the TTL could still race — hence the config warning. See also the
+>   **credential-package unification** note under *Security architecture*.
 
 ### M3 — `cred_free` releases storage before releasing its lock
 *Medium · Resolved (2026-07-02, PR #85 / issue #84) · Effort XS · `credentials/src/credfree.c:42-45` · audit M2*
@@ -644,6 +667,7 @@ for frequently-called endpoints and enable mvsMF integration.
 | SSI echo var guard (S12) | **Resolved (2026-07-03)** | `!var \|\| !*var` — `httpfile.c`, PR #93 / issue #92 |
 | `crt->crtufs` dangling after `ufsfree` (M6) | **Resolved (2026-07-03)** | clear alias before free — `httpclos.c`, PR #93 / issue #92 |
 | `cgictx` array not freed at `terminate()` (M11) | **Resolved (2026-07-03)** | `free(httpd->cgictx)` — `httpd.c`, PR #93 / issue #92 |
+| Credential reaper / session timeout (M2) | **Resolved (2026-07-03)** | `cred_reap` + refresh + `SESSION_TIMEOUT` + cap + `TSTEXPIRE` — `credentials/`+`httpd.c`+`httpprm.c`, PR #95 / issue #94 |
 
 ---
 
@@ -677,6 +701,10 @@ EBCDIC.
   §3.3.3). **Dual** (host + MVS); 16 assertions over the decision table
   (absent/zero/valid/oversize/negative/junk/OWS/`Transfer-Encoding`).
   *(PR #89 / issue #88.)*
+- `TSTEXPIRE` — `credexp()` credential-reaper expiry decision (**M2**). **Dual**
+  (host + MVS); 9 assertions (`ttl==0`, strict `>` boundary, clock skew). The
+  reaper's real risk is `cred_reap()`'s concurrency — behavioural/MVS-only.
+  *(PR #95 / issue #94.)*
 
 **Open — pure helpers, cleanly unit-testable (good next targets)**
 - **`httpcmp`/`httpcmpn`** — EBCDIC caseless compare (collation correctness; XS).
@@ -718,8 +746,8 @@ EBCDIC.
    (PR #81)**; ~~**S6**~~ **✔ (PR #83)**; ~~**M3** (unlock/free swap), **M4**,
    **M5** (one-line robustness)~~ **✔ (PR #85)**. **Step 2 complete.**
 3. **Memory stability:** ~~**M8**/**M9**/**M10** (env/CGI alloc hygiene)~~ **✔
-   (PR #87)**; remaining: **M2** (credential reaper — also closes the
-   session-timeout security gap).
+   (PR #87)**; ~~**M2** (credential reaper / session timeout)~~ **✔ (PR #95)**.
+   **Step 3 complete.**
 4. **Performance:** **P1** (env-lookup index — biggest CPU win), then **P2**/**P3**
    (one send-state machine), **P4**.
 5. **Hardening:** ~~**S4**~~ (already mitigated — finding corrected), ~~**S7**~~
@@ -836,3 +864,14 @@ Counts Security 5→4. With **S7** this closes the request-body DoS pair.
 Counts Security 4→1, M&S 6→4. **S11** (request-line `strtok` rewrite) and **P4**
 (`memset` reduction) were deliberately deferred (regression risk / perf,
 disproportionate to their Low severity).
+
+**2026-07-03:** **M2** (credential reaper / session timeout) implemented across
+`credentials/` (`credreap.c`, `credexp.c`, refresh in `credfbtk.c`, cap in
+`credlin.c`), `httpd.c` (throttled sweep in `socket_thread`), `httpprm.c`
+(`SESSION_TIMEOUT`, default 30 min, `0`=off; warns if `<= CLIENT_TIMEOUT`) and
+`httpd.h` (`cfg_session_timeout` in reused padding). Reviewed design: reject-on-
+full cap (no eviction), free-after-unlock in the sweep, refresh-at-lookup + the
+`SESSION_TIMEOUT >> longest-request` invariant as the UAF guard. Pure `credexp`
+dual-tested (`TSTEXPIRE`, 9, native). PR #95, issue #94. Counts M&S 4→3.
+**Also filed:** the *credential-package unification* item (httpd creds vs mvsMF's
+own auth — two tracks to converge) under *Security architecture*.

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -150,7 +150,7 @@ struct httpd {
     char        codepage[16];       /* 124 codepage name            */
     UCHAR       cfg_keepalive_timeout; /* 134 keepalive idle secs   */
     UCHAR       cfg_keepalive_max;  /* 135 max reqs per connection  */
-    UCHAR       unused_136[2];      /* 136 alignment padding        */
+    USHRT       cfg_session_timeout; /* 136 credential idle TTL (min), 0=off */
 };                                  /* 138                          */
 
 /* HTTP variables */

--- a/project.toml
+++ b/project.toml
@@ -101,6 +101,12 @@ sources = ["test/tstsafe.c", "src/httpesc.c", "src/httpsrdr.c"]
 name = "TSTBODY"
 sources = ["test/tstbody.c", "src/httpbody.c"]
 
+# credexp() credential-reaper expiry decision (M2 session timeout).  Free of
+# project headers -> DUAL (host + MVS); helper source listed for the host link.
+[[test]]
+name = "TSTEXPIRE"
+sources = ["test/tstexpire.c", "credentials/src/credexp.c"]
+
 # http_new_env() / httpnenv() env-block allocation + layout (guards the M9
 # offsetof sizing).  Needs the HTTPV struct via httpd.h, so MVS-only; httpnenv
 # (HTTPNENV) resolves from the [internal] autocall archive.

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -437,6 +437,7 @@ socket_thread(void *arg1, void *arg2)
     fd_set      read;
     struct sockaddr_in addr;
     struct sockaddr_in *a = (struct sockaddr_in *)&addr;
+    time64_t    last_sweep = time64(NULL);  /* credential reaper throttle (M2) */
 
     http_enter("socket_thread()\n");
 
@@ -449,6 +450,17 @@ socket_thread(void *arg1, void *arg2)
     /* we loop until we're shut down */
     while(task) {
         if (httpd->flag & HTTPD_FLAG_SHUTDOWN) break;
+
+        /* periodically reap idle credentials (M2), throttled to ~60s so the
+           select loop's ~1/s wakeups don't sweep every tick */
+        {
+            time64_t now = time64(NULL);
+            if (difftime64(now, last_sweep) >= 60.0) {
+                last_sweep = now;
+                if (httpd->cfg_session_timeout)
+                    cred_reap((unsigned)httpd->cfg_session_timeout * 60);
+            }
+        }
 
         /* process clients */
         if (process_clients(&read, NULL, NULL)) break;

--- a/src/httpprm.c
+++ b/src/httpprm.c
@@ -86,6 +86,19 @@ http_config(HTTPD *httpd, const char *member)
          httpd->cfg_client_timeout);
     wtof("HTTPD034I KEEPALIVE_TIMEOUT=%d KEEPALIVE_MAX=%d",
          httpd->cfg_keepalive_timeout, httpd->cfg_keepalive_max);
+    wtof("HTTPD035I SESSION_TIMEOUT=%d min%s", httpd->cfg_session_timeout,
+         httpd->cfg_session_timeout ? "" : " (reaper disabled)");
+
+    /* the reaper must not free a credential still borrowed by an in-flight
+       request: SESSION_TIMEOUT (min) must exceed the longest request
+       (CLIENT_TIMEOUT, sec, and worst-case CGI runtime).  Warn on an unsafe
+       config (M2). */
+    if (httpd->cfg_session_timeout &&
+        (long)httpd->cfg_session_timeout * 60 <= httpd->cfg_client_timeout) {
+        wtof("HTTPD035W SESSION_TIMEOUT (%d min) <= CLIENT_TIMEOUT (%d sec); "
+             "raise it well above the longest request",
+             httpd->cfg_session_timeout, httpd->cfg_client_timeout);
+    }
 
     return 0;
 }
@@ -116,6 +129,7 @@ set_defaults(HTTPD *httpd)
     httpd->dbg_enabled      = 0;
     httpd->cfg_keepalive_timeout = 5;
     httpd->cfg_keepalive_max     = 100;
+    httpd->cfg_session_timeout   = 30;      /* credential idle TTL (min), 0=off */
 }
 
 /* ====================================================================
@@ -214,6 +228,13 @@ parse_keyvalue(HTTPD *httpd, const char *key, const char *value)
             if (i > 255) i = 255;
             httpd->cfg_client_timeout = (UCHAR)i;
         }
+    }
+    else if (strcmp(key, "SESSION_TIMEOUT") == 0) {
+        /* credential idle TTL in minutes; 0 disables reaping (M2) */
+        i = atoi(value);
+        if (i < 0) i = 0;
+        if (i > 65535) i = 65535;
+        httpd->cfg_session_timeout = (USHRT)i;
     }
     else if (strcmp(key, "LOGIN") == 0) {
         parse_login(httpd, value);

--- a/test/tstexpire.c
+++ b/test/tstexpire.c
@@ -1,0 +1,35 @@
+/* TSTEXPIRE.C
+** Tests for credexp() -- the credential-reaper expiry decision (M2,
+** credentials/src/credexp.c).
+**
+** credexp() is free of project headers, so this is a DUAL test: it runs
+** natively via `make test-host` and on MVS via `make test-mvs`.  It only
+** covers the (trivial) boundary logic; the reaper's real risk is the
+** concurrency in cred_reap(), which is behavioural / MVS-only.
+*/
+#include <stdio.h>
+#include <mbtcheck.h>
+
+extern int credexp(long elapsed_secs, unsigned ttl_secs);
+
+int main(void)
+{
+    printf("=== HTTPD credexp (session-timeout) tests ===\n");
+
+    /* ttl == 0 disables reaping: never expired, whatever the age */
+    CHECK(credexp(0, 0) == 0,        "ttl 0 -> never (idle 0)");
+    CHECK(credexp(1000000, 0) == 0,  "ttl 0 -> never (very idle)");
+
+    /* strict '>' boundary: exactly at the TTL is still live */
+    CHECK(credexp(0, 30) == 0,       "idle 0 < ttl 30 -> live");
+    CHECK(credexp(29, 30) == 0,      "idle 29 < ttl 30 -> live");
+    CHECK(credexp(30, 30) == 0,      "idle 30 == ttl 30 -> live (strict >)");
+    CHECK(credexp(31, 30) == 1,      "idle 31 > ttl 30 -> expired");
+    CHECK(credexp(100000, 60) == 1,  "far past ttl -> expired");
+
+    /* clock skew: last > now (negative elapsed) is never expired */
+    CHECK(credexp(-1, 30) == 0,      "negative elapsed (skew) -> live");
+    CHECK(credexp(-100000, 30) == 0, "large negative elapsed -> live");
+
+    return mbt_test_summary("TSTEXPIRE");
+}


### PR DESCRIPTION
## What

Implements **M2** — a credential reaper / **session timeout**. The process-wide CRED array had no expiry: `cred->last` was written in `cred_new()` and never read, so a `CRED` (~80 B) + its RACF **ACEE** was removed only by an explicit `/logout` or shutdown → idle sessions grew unbounded.

## How (design reviewed)

- **Refresh** `cred->last = time64(NULL)` on every `cred_find_by_token()` hit — the *only* per-request lookup (`by_id`/`by_acee` are unused, verified). Activity keeps a session alive.
- **Reaper** `cred_reap(ttl_secs)` (`credreap.c`): walks the WSA array under `LOCK_EXC`, `array_del`s entries idle > TTL (skipping any `testlock` shows in-use), then `cred_free`s them (RACF logout) **after releasing** the array lock so a mass expiry doesn't stall workers. Mirrors `cred_free_array()`.
- **Decision** extracted as a pure `credexp(long elapsed, unsigned ttl)` (`ttl==0` → never; negative elapsed → not yet; strict `>` boundary) — **dual-tested** (`TSTEXPIRE`).
- **Sweep** runs in the `socket_thread` select loop, throttled ~60 s — **no new thread**. `cred_array()` is AS-wide (per-process WSA; `clibwsa.h`), so the socket_thread sees the workers' creds (verified).
- **Config** `SESSION_TIMEOUT <min>` in Parmlib (default **30**, `0` = disabled) → `httpd->cfg_session_timeout` (reuses the `unused_136` padding, no HTTPD growth). `httpprm` warns if `SESSION_TIMEOUT <= CLIENT_TIMEOUT`.
- **Cap** in `cred_login()`: reject a new login when the array is full (`CRED_MAX` 256) — **no eviction** of a live session (evicting under a login flood would drop a good user / risk a UAF).

## UAF — stated honestly

A worker borrows `httpc->cred` for a request. The array lock serialises lookup vs sweep, and refresh-at-lookup keeps an *actively used* cred fresh, so the reaper never reaps an in-use session **as long as `SESSION_TIMEOUT` >> the longest request** (`CLIENT_TIMEOUT`, and worst-case CGI runtime — mvsMF dataset/JES ops run minutes). `testlock` only catches a concurrent *free*, not a borrow — hence the config warning, not a false sense of safety.

## Verification

- **`TSTEXPIRE` — 9 assertions, run natively (`make test-host`): pass** (`ttl==0`, strict boundary, clock skew). Full host suite green (51 assertions).
- **cc370** clean: `credexp`, `credreap`, `credfbtk`, `credlin`, `httpprm`, `httpd`; CSECTs `CREDEXP`/`CREDREAP` link (`=V(CREDEXP)` in credreap, `=V(CREDREAP)` in httpd).
- **Behavioural (MVS, please run):** set a short `SESSION_TIMEOUT`, log in, idle past it → the CRED **and its ACEE** are reaped (watch for the RACF logout); a session kept active across the interval survives; a login flood past `CRED_MAX` is rejected (401/retry), not a crash.

## Cross-cutting (documented, not code)

Filed a **credential-package unification** item under *Security architecture*: httpd's creds and mvsMF's own auth are two separate tracks; they should converge after a joint analysis.

## Docs

`docs/refactoring-backlog.md`: M2 resolved, session-timeout arch item delivered, counts M&S 4→3, `TSTEXPIRE` added, order step 3 complete, unification note filed.

Fixes #94
