### PR TITLE
Auth 4/6 (httpd): HTTPX auth export (get_userid / get_acee / get_token / logout / check_auth)

### DIFF
--- a/include/httpcgi.h
+++ b/include/httpcgi.h
@@ -42,6 +42,7 @@
 
 typedef struct httpd    HTTPD;      /* HTTP Daemon (server) — opaque    */
 typedef struct cred     CRED;       /* Credentials          — opaque    */
+struct acee;                        /* RACF ACEE — full def via <racf.h> */
 #ifndef LIBUFS_H
 typedef struct ufs      UFS;        /* UFS filesystem       — opaque    */
 typedef struct ufsfile  UFSFILE;    /* UFS file handle      — opaque    */
@@ -297,6 +298,17 @@ struct httpx {
                                     /* 120 get/create UFS handle        */
     void *      (*http_cgictx_get)(HTTPD *, const char *, unsigned);
                                     /* 124 find/create CGI context      */
+    UCHAR *     (*http_get_userid)(HTTPC *, UCHAR *out, unsigned outlen);
+                                    /* 128 client userid into buf       */
+    struct acee *(*http_get_acee)(HTTPC *);
+                                    /* 12C client RACF ACEE / NULL      */
+    int         (*http_get_token)(HTTPC *, UCHAR *out, unsigned outlen);
+                                    /* 130 copy session token, ret len  */
+    int         (*http_check_auth)(HTTPC *, const char *classname,
+                                   const char *resource, int attr);
+                                    /* 134 RACF resource check          */
+    int         (*http_logout)(HTTPC *);
+                                    /* 138 end client session           */
 };
 
 /* Eye-catcher for HTTPD pointer identification (ABI constant) */
@@ -523,5 +535,20 @@ struct httpx {
 
 #define http_cgictx_get(httpd,eye,size) \
     ((httpx->http_cgictx_get)((httpd),(eye),(size)))
+
+#define http_get_userid(httpc,out,outlen) \
+    ((httpx->http_get_userid)((httpc),(out),(outlen)))
+
+#define http_get_acee(httpc) \
+    ((httpx->http_get_acee)((httpc)))
+
+#define http_get_token(httpc,out,outlen) \
+    ((httpx->http_get_token)((httpc),(out),(outlen)))
+
+#define http_check_auth(httpc,classname,resource,attr) \
+    ((httpx->http_check_auth)((httpc),(classname),(resource),(attr)))
+
+#define http_logout(httpc) \
+    ((httpx->http_logout)((httpc)))
 
 #endif /* HTTPCGI_H */

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -417,6 +417,17 @@ struct httpx {
                                     /* 120 get/create UFS handle    */
     void *      (*http_cgictx_get)(HTTPD *, const char *, unsigned);
                                     /* 124 find/create CGI context  */
+    UCHAR *     (*http_get_userid)(HTTPC *, UCHAR *out, unsigned outlen);
+                                    /* 128 client userid into buf   */
+    ACEE *      (*http_get_acee)(HTTPC *);
+                                    /* 12C client RACF ACEE / NULL  */
+    int         (*http_get_token)(HTTPC *, UCHAR *out, unsigned outlen);
+                                    /* 130 copy session token, ret len */
+    int         (*http_check_auth)(HTTPC *, const char *classname,
+                                   const char *resource, int attr);
+                                    /* 134 RACF resource check      */
+    int         (*http_logout)(HTTPC *);
+                                    /* 138 end client session       */
 };
 
 extern int http_in(HTTPC*)                                              asm("HTTPIN");
@@ -481,6 +492,12 @@ extern int http_process_cgi(HTTPC *httpc, HTTPCGI *cgi)                 asm("HTT
 extern unsigned char *http_xlate(unsigned char *, int, const unsigned char *) asm("HTTPXLAT");
 extern UFS *http_get_ufs(HTTPC *)                                          asm("HTTPGUFS");
 extern void *http_cgictx_get(HTTPD *, const char *, unsigned)              asm("HTTPGCTX");
+extern UCHAR *http_get_userid(HTTPC *, UCHAR *out, unsigned outlen)         asm("HTTPGUID");
+extern ACEE *http_get_acee(HTTPC *)                                        asm("HTTPGACE");
+extern int http_get_token(HTTPC *, UCHAR *out, unsigned outlen)            asm("HTTPGTOK");
+extern int http_check_auth(HTTPC *, const char *classname,
+                           const char *resource, int attr)                asm("HTTPCKAU");
+extern int http_logout(HTTPC *)                                           asm("HTTPLOUT");
 extern double httpsecs(double *psecs)									asm("HTTPSECS");
 extern int httpcred(HTTPC *httpc)										asm("HTTPCRED");
 extern int httpd048(HTTPD *httpd)										asm("HTTPD048");
@@ -709,6 +726,21 @@ extern int http_gets(HTTPC *httpc, UCHAR *buf, unsigned max)            asm("HTT
 
 #define http_cgictx_get(httpd,eye,size) \
     ((httpx->http_cgictx_get)((httpd),(eye),(size)))
+
+#define http_get_userid(httpc,out,outlen) \
+    ((httpx->http_get_userid)((httpc),(out),(outlen)))
+
+#define http_get_acee(httpc) \
+    ((httpx->http_get_acee)((httpc)))
+
+#define http_get_token(httpc,out,outlen) \
+    ((httpx->http_get_token)((httpc),(out),(outlen)))
+
+#define http_check_auth(httpc,classname,resource,attr) \
+    ((httpx->http_check_auth)((httpc),(classname),(resource),(attr)))
+
+#define http_logout(httpc) \
+    ((httpx->http_logout)((httpc)))
 
 #endif  /* ifndef HTTPX_H */
 

--- a/src/httpx.c
+++ b/src/httpx.c
@@ -79,6 +79,11 @@ static HTTPX vect = {
     &http_legacy,               /* 11C legacy hybrid codepage pair  */
     http_get_ufs,               /* 120 http_get_ufs()               */
     http_cgictx_get,            /* 124 http_cgictx_get()            */
+    http_get_userid,            /* 128 http_get_userid()            */
+    http_get_acee,              /* 12C http_get_acee()              */
+    http_get_token,             /* 130 http_get_token()             */
+    http_check_auth,            /* 134 http_check_auth()            */
+    http_logout,                /* 138 http_logout()                */
 };
 
 HTTPX *httpx = &vect;

--- a/src/httpxauth.c
+++ b/src/httpxauth.c
@@ -1,0 +1,102 @@
+/* HTTPXAUTH.C
+** HTTPX auth accessors — let CGI modules reach the resolved client
+** credential (httpc->cred) through the function vector, without linking the
+** credentials package or dereferencing CRED/ACEE layout themselves.
+**
+** All accessors are NULL-credential safe (an unauthenticated request has
+** httpc->cred == NULL).  Exported through the HTTPX vector (append-only):
+**   http_get_userid  http_get_acee  http_get_token  http_check_auth
+**   http_logout
+**
+** Each function carries a >8-char C name, so it needs an explicit &FUNC CSECT
+** name (matching its asm() alias) and an #undef to shed the httpx macro layer
+** (HTTP_PRIVATE also suppresses it) — same pattern as httpgufs.c.
+*/
+#define HTTP_PRIVATE
+#include "httpd.h"
+
+/* http_get_userid() - copy the client's (decrypted) userid into the caller's
+** buffer as a NUL-terminated string.  Returns out on success, or NULL if
+** there is no credential (or no room).  The transient decrypted CREDID also
+** exposes the password, so it is scrubbed before returning. */
+__asm__("\n&FUNC SETC 'HTTPGUID'");
+#undef http_get_userid
+UCHAR *
+http_get_userid(HTTPC *httpc, UCHAR *out, unsigned outlen)
+{
+    CREDID   id;
+    unsigned n;
+
+    if (!out || outlen == 0) return NULL;
+    out[0] = 0;
+
+    if (!httpc || !httpc->cred) return NULL;
+
+    credid_dec(&httpc->cred->id, &id);
+
+    /* id.userid is a NUL-terminated 8+0 field; copy it bounded + terminate */
+    for (n = 0; n < outlen - 1 && id.userid[n]; n++) {
+        out[n] = id.userid[n];
+    }
+    out[n] = 0;
+
+    memset(&id, 0, sizeof(id));   /* scrub the decrypted userid/password */
+    return out;
+}
+
+/* http_get_acee() - the client's RACF ACEE, or NULL when the request is not
+** authenticated.  A CGI may hand this to racf_set_acee()/racf_auth() to run
+** work under the client's identity. */
+__asm__("\n&FUNC SETC 'HTTPGACE'");
+#undef http_get_acee
+ACEE *
+http_get_acee(HTTPC *httpc)
+{
+    if (!httpc || !httpc->cred) return NULL;
+    return httpc->cred->acee;
+}
+
+/* http_get_token() - copy the client's opaque session token into the caller's
+** buffer.  Returns the number of bytes copied (0 if there is no session or the
+** buffer is too small).  The caller base64-encodes exactly that many bytes
+** (e.g. to hand back a z/OSMF LtpaToken2 cookie). */
+__asm__("\n&FUNC SETC 'HTTPGTOK'");
+#undef http_get_token
+int
+http_get_token(HTTPC *httpc, UCHAR *out, unsigned outlen)
+{
+    if (!httpc || !httpc->cred || !out) return 0;
+    if (outlen < sizeof(CREDTOK)) return 0;
+
+    memcpy(out, httpc->cred->token.c, sizeof(CREDTOK));
+    return (int)sizeof(CREDTOK);
+}
+
+/* http_check_auth() - RACF resource check under the client's ACEE.  attr is
+** one of RACF_ATTR_READ/UPDATE/CONTROL/ALTER (0 -> READ).  Returns the
+** racf_auth() rc (0 == access permitted), or -1 when unauthenticated. */
+__asm__("\n&FUNC SETC 'HTTPCKAU'");
+#undef http_check_auth
+int
+http_check_auth(HTTPC *httpc, const char *classname, const char *resource, int attr)
+{
+    if (!httpc || !httpc->cred || !httpc->cred->acee) return -1;
+    return racf_auth(httpc->cred->acee, classname, resource, attr);
+}
+
+/* http_logout() - end the client's session: drop the CRED (and its ACEE) from
+** the credential store by token and clear httpc->cred.  Returns 0 on success,
+** -1 if there was no session. */
+__asm__("\n&FUNC SETC 'HTTPLOUT'");
+#undef http_logout
+int
+http_logout(HTTPC *httpc)
+{
+    int rc;
+
+    if (!httpc || !httpc->cred) return -1;
+
+    rc = credtok_logout(&httpc->cred->token);
+    httpc->cred = NULL;   /* the CRED it pointed at may now be freed */
+    return rc;
+}


### PR DESCRIPTION
Adds the HTTPX auth export from the auth redesign (`docs/auth-redesign.md` §2.4): five credential accessors appended to the HTTPX vector so CGI modules (mvsMF) reach the resolved client credential through the vector instead of running their own auth.

## What

Append-only vector slots `0x128`–`0x138` (offsets never change; mirrored in `httpd.h`, `httpcgi.h`, `httpx.c` in lockstep), implemented in the new `src/httpxauth.c`:

| Slot | Function | Purpose |
|------|----------|---------|
| 0x128 | `http_get_userid(httpc, out, outlen)` | decrypt the client userid into a caller buffer |
| 0x12C | `http_get_acee(httpc)` | the client's RACF `ACEE` (or `NULL`) |
| 0x130 | `http_get_token(httpc, out, outlen)` | copy the opaque session token, returns byte count |
| 0x134 | `http_check_auth(httpc, class, resource, attr)` | `racf_auth()` under the client's ACEE |
| 0x138 | `http_logout(httpc)` | `credtok_logout()` + clears `httpc->cred` |

All accessors are NULL-credential safe (an unauthenticated request has `httpc->cred == NULL`).

## Signature notes (divergence from the doc sketch)

- **`get_userid` / `get_token` take a caller buffer** instead of returning a pointer, on purpose:
  - the plaintext userid only exists in a transient decrypted `CREDID` (scrubbed before return so the co-decrypted password doesn't linger on the stack);
  - a returned `CREDTOK*` would alias into the shared `cred_array`, which `cred_reap()` can free under the caller. A copy is lifetime-safe.
- **`get_acee` is kept** (vs. dropping it in favour of `check_auth`): mvsMF's `authmw.c` calls `racf_set_acee()` and `ussapi.c` reads `aceeuser`/`aceegrp`, so the ACEE itself is needed, not just a resource check.
- **`httpcgi.h` forward-declares `struct acee` as a tag** (not a typedef), so it coexists with `<racf.h>`'s own `ACEE` typedef under `-Werror` in either include order; `get_token`'s caller buffer keeps `CREDTOK` out of the CGI header entirely.

## Verification

- `make modules` — clean `cc370` compile under `-Wall -Werror`; all 6 load modules link (HTTPX offsets intact); the five CSECTs (`HTTPGUID`/`HTTPGACE`/`HTTPGTOK`/`HTTPCKAU`/`HTTPLOUT`) present in `httpdint.a`.
- CGI-consumer smoke compile (`#include "httpcgi.h"` then `#include "racf.h"`, using all five accessors + `ACEE *a = http_get_acee(...)` + `racf_set_acee(a)`) compiles clean under `-Wall -Werror` — confirms the `struct acee` tag/typedef coexistence.

Epic #100 step 4/6. Unblocks mvslovers/mvsmf#160 / #162 (authenticate endpoint drops `authmw.c` and uses this export).

Fixes #99