### PR TITLE
Auth 3/6 (httpd): per-route auth policy (MOD=/LOC=) + 2-stage pipeline gate

### DIFF
--- a/docs/auth-redesign.md
+++ b/docs/auth-redesign.md
@@ -226,19 +226,23 @@ the token-model note in §4.
 ## 3. Migration path
 
 ### 3.1 httpd (the foundation)
-1. **Basic Auth source** + `WWW-Authenticate` challenge + factor the credential
-   resolver (cookie → Basic → Bearer). *(no `credentials/` change)*
-2. **Accept the session token back** on later requests: extend the resolver to
-   read a `LtpaToken2` cookie (and/or `Authorization: Bearer <token>`) →
-   `cred_find_by_token`. *(The `/zosmf/services/authenticate` endpoint itself is
-   mvsMF's — httpd only accepts the token and exposes it via 4.)*
-3. **Per-route policy**: `MOD=` (CGI) **and** `LOC=` (static prefix) carry the
-   same policy; a **2-stage gate in the pipeline** — authenticate (→401) then,
-   if `RES=` is set, `racf_auth` (→403) — applied *before* serving a file or
-   dispatching a CGI, so static/SPA routes get RACF/RAKF protection too. Decouple
-   the challenge (form vs 401) from the core.
-4. **HTTPX auth export** (`get_userid`/`get_acee`/`get_token`/`logout`/
-   `check_auth`).
+1. ✅ **(done — #96)** **Basic Auth source** + `WWW-Authenticate` challenge +
+   factor the credential resolver (cookie → Basic → Bearer). *(no `credentials/`
+   change)*
+2. ✅ **(done — #97)** **Accept the session token back** on later requests:
+   extend the resolver to read a `LtpaToken2` cookie (and/or `Authorization:
+   Bearer <token>`) → `cred_find_by_token`. *(The `/zosmf/services/authenticate`
+   endpoint itself is mvsMF's — httpd only accepts the token and exposes it via
+   4.)*
+3. ✅ **(done — #98)** **Per-route policy**: `MOD=` (CGI) **and** `LOC=` (static
+   prefix) carry the same policy; a **2-stage gate in the pipeline** —
+   authenticate (→401) then, if `RES=` is set, `racf_auth` (→403) — applied
+   *before* serving a file or dispatching a CGI, so static/SPA routes get
+   RACF/RAKF protection too. Decouple the challenge (form vs 401) from the core.
+   *(`AUTH=` is `NONE`/`FORM`/`BASIC`; a route without `AUTH=` inherits the
+   global `LOGIN` default.)*
+4. ✅ **(done — #99)** **HTTPX auth export** (`get_userid`/`get_acee`/
+   `get_token`/`logout`/`check_auth`).
 
 ### 3.2 mvsMF
 5. Implement `POST`/`DELETE /zosmf/services/authenticate` (mvslovers/mvsmf#162):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,37 @@ All static content (HTML, CSS, JS, images) is served from this directory. Server
 
 When `LOGIN=RACF`, unauthenticated requests to protected resources receive a redirect to the login page. After successful RACF authentication, a `Sec-Token` cookie is issued. Sessions are bound to the client's IP address.
 
+`LOGIN` remains the global default. Individual routes can override it and add a
+resource check with the per-route `AUTH=` / `RES=` options (see below).
+
+### Per-route authentication policy (`AUTH=`, `RES=`)
+
+Both `MOD=` (a CGI route) and `LOC=` (a program-less static route) can carry a
+per-route auth policy as trailing options. The server enforces it in its request
+pipeline as a **2-stage gate**, uniformly for CGI and static routes, *before* it
+serves a file or dispatches a CGI:
+
+1. **Authenticate** — the credential is resolved from the request (`Sec-Token` /
+   `LtpaToken2` cookie, `Authorization: Bearer`, or `Authorization: Basic`). If
+   the route requires an identity and none is present, the server answers **401**
+   with the challenge selected by `AUTH=`.
+2. **Authorize** — if the route sets `RES=class:resource`, the server issues a
+   RACF/RAKF check (RACHECK/FRACHECK) under the client's ACEE. On denial it
+   answers **403**.
+
+| Option | Values | Description |
+|--------|--------|-------------|
+| `AUTH=` | `NONE` \| `FORM` \| `BASIC` | Challenge for stage 1. `NONE` = public (no authentication). `FORM` = redirect to the HTML login form. `BASIC` = `401 WWW-Authenticate: Basic`. **Omitted** = inherit the global `LOGIN` default (backward compatible). |
+| `RES=` | `class:resource` | Optional RACF/RAKF resource for stage 2, e.g. `RES=FACILITY:MVSMF.ACCESS`. Checked for `READ`. A resource always requires an identity, so it implies authentication even without `AUTH=`. |
+
+The credential resolver always tries every source, so `AUTH=` only selects the
+*challenge* shown when authentication is missing — it does not restrict which
+source a client may use. `AUTH=NONE` combined with `RES=` is contradictory (a
+public route has no ACEE to check) — the server warns and `NONE` wins.
+
+`/login`, `/logout` and the login-page assets (`/login.*`, `/favicon.*`) are
+always reachable so an `AUTH=FORM` challenge can render.
+
 ## Timezone
 
 | Keyword | Default | Description |
@@ -70,9 +101,13 @@ When `LOGIN=RACF`, unauthenticated requests to protected resources receive a red
 ```
 MOD=PROGRAM /url/pattern        URL prefix match
 MOD=PROGRAM                     Extension match (derives *.program from name)
+MOD=PROGRAM /url/pattern AUTH=BASIC RES=class:resource   with auth policy
 ```
 
 Server modules are load modules that HTTPD loads at startup via `__load()` and calls directly through the HTTPX function vector. They run inside the server's address space — unlike traditional CGI programs which fork a new process per request.
+
+Any `MOD=` route may add the per-route `AUTH=` / `RES=` options described under
+[Security](#security).
 
 | Routing Type | Syntax | Behavior |
 |-------------|--------|----------|
@@ -104,6 +139,35 @@ MOD=MVSMF /zosmf/*
 MOD=MVSMF /zosmf/*
 MOD=HTTPDSRV /.dsrv
 MOD=HTTPDMTT /.dmtt
+```
+
+## Static Locations (`LOC=`)
+
+```
+LOC=/url/prefix                 static path prefix (falls through to DOCROOT)
+LOC=/url/prefix AUTH=mode RES=class:resource   with auth policy
+```
+
+A `LOC=` route matches a path **without** a program: the request falls through
+to the normal static file handler (`DOCROOT`), but the route still carries the
+same per-route `AUTH=` / `RES=` policy as `MOD=`. This lets a whole static
+subtree (an SPA, an admin area) sit behind a login or a RACF/RAKF profile without
+a CGI.
+
+Path matching is the same as for `MOD=`: a path is matched **exactly** unless it
+contains a wildcard, so a subtree needs a trailing `*` (`LOC=/admin/*`, not
+`LOC=/admin`). Routes are tested in the order they appear, so list the more
+specific prefixes before a catch-all — a catch-all `LOC=/*` must come *after*
+`MOD=MVSMF /zosmf/*`, or it shadows it.
+
+```
+# SPA: the whole document tree is public (the login page must load), the API
+# is protected -- list the API route first so the catch-all doesn't shadow it
+MOD=MVSMF /zosmf/*     AUTH=BASIC RES=FACILITY:MVSMF.ACCESS
+LOC=/*                 AUTH=NONE
+
+# Static admin area behind a RACF profile
+LOC=/admin/*          AUTH=BASIC RES=FACILITY:HTTPD.ADMIN
 ```
 
 ## SMF Recording

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -238,11 +238,25 @@ struct httpcgi {
     UCHAR       eye[8];             /* 00 Eye catcher for dumps     */
 #define HTTPCGI_EYE  "HTTPCGI"      /* ...                          */
     UCHAR       wild;               /* 08 '*' or '?' in path name   */
-	UCHAR		login;				/* 09 login required			*/
+	UCHAR		login;				/* 09 login required (legacy)	*/
     USHRT       len;                /* 0A Path length               */
     char  		*path;              /* 0C Path name to match        */
-    char  		*pgm;               /* 10 external program name     */
-};									/* 14 (20 bytes)				*/
+    char  		*pgm;               /* 10 program (NULL = LOC route) */
+    /* per-route auth policy -- append-only.  HTTPCGI is heap-allocated and
+       opaque to CGI modules (httpcgi.h), so appending fields is safe. */
+    UCHAR       auth;               /* 14 AUTH mode (HTTP_AUTH_*)   */
+    UCHAR       resattr;            /* 15 RACF attr (RACF_ATTR_*)   */
+    char        *resclass;          /* 18 RACF class (NULL = none)  */
+    char        *resname;           /* 1C RACF resource name        */
+};									/* 20 (32 bytes)				*/
+
+/* HTTPCGI.auth -- per-route authentication mode.  DEFAULT (0) means the route
+   carried no AUTH= keyword and inherits the legacy global LOGIN policy, so
+   existing Parmlib members and calloc'd routes keep their old behavior. */
+#define HTTP_AUTH_DEFAULT 0         /* no AUTH= -> inherit global LOGIN     */
+#define HTTP_AUTH_NONE    1         /* AUTH=NONE  -> public, no challenge   */
+#define HTTP_AUTH_FORM    2         /* AUTH=FORM  -> HTML login form        */
+#define HTTP_AUTH_BASIC   3         /* AUTH=BASIC -> 401 WWW-Authenticate   */
 
 /* SMF — HTTP records */
 #define SMF_TYPE_HTTPD_DEFAULT 243

--- a/src/httpacgi.c
+++ b/src/httpacgi.c
@@ -1,5 +1,7 @@
 /* httpacgi() - add path and pgm to array of HTTPCGI in HTTPD handle
    note: pgm and path much be literal string constants that do not change.
+   A NULL pgm registers a program-less (LOC=) route: a static path prefix
+   that carries auth policy but falls through to httpget instead of a CGI.
 */
 #include "httpd.h"
 
@@ -8,7 +10,6 @@ HTTPCGI *httpacgi(HTTPD *httpd, const char *pgm, const char *path, int login)
     HTTPCGI *cgi    = NULL;
 
     if (!httpd) goto quit;
-    if (!pgm) goto quit;
     if (!path) goto quit;
 
     cgi = calloc(1, sizeof(HTTPCGI));
@@ -21,12 +22,13 @@ HTTPCGI *httpacgi(HTTPD *httpd, const char *pgm, const char *path, int login)
     cgi->login = (login ? 1 : 0);
     cgi->len  = strlen(path);
     cgi->path = strdup(path);
-    cgi->pgm  = strdup(pgm);
+    cgi->pgm  = pgm ? strdup(pgm) : NULL;   /* NULL pgm == LOC route */
 
-    /* on OOM don't register a half-built entry -- a NULL path/pgm would
-       NULL-deref later at CGI match/link.  (For a successfully registered
-       entry the strdup storage is AS-lifetime by design.) */
-    if (!cgi->path || !cgi->pgm) {
+    /* on OOM don't register a half-built entry -- a NULL path would NULL-deref
+       later at CGI match; a NULL pgm from a failed strdup (pgm was non-NULL)
+       would NULL-deref at CGI link.  (For a successfully registered entry the
+       strdup storage is AS-lifetime by design.) */
+    if (!cgi->path || (pgm && !cgi->pgm)) {
         free(cgi->path);
         free(cgi->pgm);
         free(cgi);

--- a/src/httpdbug.c
+++ b/src/httpdbug.c
@@ -72,7 +72,7 @@ dump_cgi(HTTPD *httpd, HTTPC *httpc)
         if (!p) continue;
         
         http_printf(httpc, "   Path=\"%s\" Program=\"%s\" Login=%u Wild=%u\n",
-			p->path, p->pgm, p->login, p->wild);
+			p->path, p->pgm ? p->pgm : "(none)", p->login, p->wild);
     }
 
 quit:

--- a/src/httpdsrv.c
+++ b/src/httpdsrv.c
@@ -1513,8 +1513,8 @@ display_cgi_row(HTTPD *httpd, HTTPC *httpc, HTTPCGI *cgi, unsigned n)
     http_printf(httpc, "<tr><td>+%04X</td>"
         "<td>cgi->pgm</td>"
         "<td>Program Name</td>"
-        "<td>\"%s\"</td></tr>\n", 
-        O(pgm), cgi->pgm);
+        "<td>\"%s\"</td></tr>\n",
+        O(pgm), cgi->pgm ? cgi->pgm : "(none)");
 
 #if 0
     http_printf(httpc, "<tr><td>----------</td>"

--- a/src/httppc.c
+++ b/src/httppc.c
@@ -9,7 +9,10 @@
 
 static int  needs_login(HTTPC *httpc, HTTPCGI *cgi);
 static void resolve_credential(HTTPC *httpc);
-static int  auth_required_response(HTTPC *httpc);
+static void auth_gate(HTTPC *httpc, HTTPCGI *route);
+static int  auth_required_response(HTTPC *httpc, UCHAR mode);
+static int  forbidden_response(HTTPC *httpc);
+static int  is_asset_exempt(const char *path);
 
 /* http_process_client() */
 int
@@ -17,9 +20,9 @@ httppc(HTTPC *httpc)
 {
 	HTTPD 	*httpd 		= httpc->httpd;
     int     rc  		= 0;
-    int		needslogin;
     char    *path;
     char	*debug;
+    HTTPCGI	*route;
 
 #if 0
     http_enter("http_process_client()\n");
@@ -49,54 +52,59 @@ httppc(HTTPC *httpc)
     case CSTATE_PUT:    /* process PUT request          */
     case CSTATE_POST:   /* process POST request         */
     case CSTATE_DELETE: /* process DELETE request       */
-        /* check this path name for CGI processing */
         path = http_get_env(httpc, "REQUEST_PATH");
 #if 0
 		wtof("httpc.c: path=\"%s\"", path ? path : "(null)");
 #endif
-        if (path) {
-            HTTPCGI *cgi = http_find_cgi(httpd, path);
+        /* resolve the client credential for this request into httpc->cred:
+           Sec-Token / LtpaToken2 cookie, Bearer, or Basic (see
+           resolve_credential) */
+        resolve_credential(httpc);
 
-            /* resolve the client credential for this request into httpc->cred:
-               Sec-Token / LtpaToken2 cookie, Bearer, or Basic (see
-               resolve_credential) */
-            resolve_credential(httpc);
+        /* find the route (MOD= CGI or LOC= static prefix) owning this path */
+        route = path ? http_find_cgi(httpd, path) : NULL;
 
-            if (cgi) {
-				if (needs_login(httpc, cgi)) {
-					/* not authenticated: 401 challenge (Basic) or login form */
-					rc = auth_required_response(httpc);
-					goto check_done;
-				}
-
-                /* extension-based CGI (pattern starts with "*."):
-                   set SCRIPT_FILENAME = docroot + request path */
-                if (cgi->path[0] == '*' && cgi->path[1] == '.') {
-                    char scriptfile[384];
-                    snprintf(scriptfile, sizeof(scriptfile), "%s%s",
-                             httpd->docroot, path);
-                    http_set_env(httpc, "SCRIPT_FILENAME", scriptfile);
-                }
-
-                /* path needs to be processed by external program */
-                rc = http_process_cgi(httpc, cgi);
-                goto check_done;
-            }
-            
-            /* process /login or /logout request */
-            if (http_cmp(path, "/login")==0 || http_cmp(path, "/logout")==0) {
-				rc = httpcred(httpc);
-				goto check_done;
-			}
+        /* /login and /logout are the auth UI endpoints: always dispatch them,
+           in every mode, so an AUTH=FORM challenge can never lock itself out */
+        if (path && (http_cmp(path, "/login")==0 ||
+                     http_cmp(path, "/logout")==0)) {
+            rc = httpcred(httpc);
+            goto check_done;
         }
 
-        /* not a CGI request */
-        needslogin = needs_login(httpc, NULL);
-		if (needslogin) {
-			rc = auth_required_response(httpc);
-			goto check_done;
-		}
-        
+        /* 2-stage gate (authenticate -> 401, authorize -> 403), applied
+           uniformly to CGI and static routes before anything is served.
+           Login-page assets (/login.*, /favicon.*) stay reachable on a read
+           request so an AUTH=FORM challenge can load its own page. */
+        {
+            int exempt = is_asset_exempt(path) &&
+                         (httpc->state == CSTATE_GET ||
+                          httpc->state == CSTATE_HEAD);
+            if (!exempt) {
+                auth_gate(httpc, route);
+                if (httpc->state == CSTATE_DONE) goto check_done;
+            }
+        }
+
+        /* CGI dispatch -- only routes that carry a program (pgm != NULL).
+           A LOC= route has pgm == NULL and falls through to static serving. */
+        if (route && route->pgm) {
+            /* extension-based CGI (pattern starts with "*."):
+               set SCRIPT_FILENAME = docroot + request path */
+            if (route->path[0] == '*' && route->path[1] == '.') {
+                char scriptfile[384];
+                snprintf(scriptfile, sizeof(scriptfile), "%s%s",
+                         httpd->docroot, path);
+                http_set_env(httpc, "SCRIPT_FILENAME", scriptfile);
+            }
+
+            /* path needs to be processed by external program */
+            rc = http_process_cgi(httpc, route);
+            goto check_done;
+        }
+
+        /* not a CGI: serve statically (route was NULL or a LOC policy route,
+           already gated above) */
         if (httpc->state == CSTATE_GET) {
             /* process GET request          */
             http_get(httpc);
@@ -311,32 +319,123 @@ resolve_credential(HTTPC *httpc)
 }
 
 /*
-** auth_required_response() - the request needs a login but isn't authenticated.
-** A client that sent an Authorization header is a REST/Basic client -> answer a
-** 401 challenge; otherwise fall back to the interactive HTML login form.
+** is_asset_exempt() - login-page assets that must load even when a wildcard
+** route would otherwise gate them, so an AUTH=FORM challenge can render its
+** page.  (/login and /logout themselves are dispatched before the gate.)
 */
 static int
-auth_required_response(HTTPC *httpc)
+is_asset_exempt(const char *path)
 {
-	int	rc;
+	if (!path) return 0;
+	if (__patmat(path, "/login.*"))   return 1;
+	if (__patmat(path, "/favicon.*")) return 1;
+	return 0;
+}
 
-	if (http_get_env(httpc, "HTTP_Authorization")) {
-		rc = http_resp(httpc, 401);
-		if (rc) goto quit;
-		rc = http_printf(httpc, "WWW-Authenticate: Basic realm=\"%s\"\r\n",
-		                 HTTP_AUTH_REALM);
-		if (rc) goto quit;
-		http_printf(httpc, "Cache-Control: no-store\r\n");
-		http_printf(httpc, "Content-Type: text/plain\r\n");
-		http_printf(httpc, "\r\n");
-		http_printf(httpc, "401 Unauthorized\n");
-		httpc->state = CSTATE_DONE;
-		return 0;
+/*
+** auth_gate() - per-route 2-stage authorization gate, run in the pipeline
+** before a file is served or a CGI is dispatched (uniform for both):
+**   Stage 1 (authenticate): does the route require an identity?  If so and the
+**     client is not authenticated -> 401 (challenge per the route's AUTH mode).
+**   Stage 2 (authorize): if the route sets RES=class:resource, RACHECK it under
+**     the client's ACEE (http_check_auth) -> 403 on deny.
+** On 401/403 the response is emitted and httpc->state is set to CSTATE_DONE;
+** the caller detects that and stops.  route == NULL (a plain static path)
+** falls back to the legacy global LOGIN default.
+*/
+static void
+auth_gate(HTTPC *httpc, HTTPCGI *route)
+{
+	UCHAR	mode   = route ? route->auth : HTTP_AUTH_DEFAULT;
+	int		authed = (httpc->cred && httpc->cred->id.addr == httpc->addr);
+	int		need_authn;
+
+	/* Stage 1: does this route require authentication? */
+	if (mode == HTTP_AUTH_NONE) {
+		need_authn = 0;
+	}
+	else if (mode == HTTP_AUTH_FORM || mode == HTTP_AUTH_BASIC) {
+		need_authn = 1;
+	}
+	else {
+		/* HTTP_AUTH_DEFAULT: inherit the legacy global LOGIN policy.  A LOC=
+		   route (program-less) is treated like a plain static path (NULL). */
+		need_authn = needs_login(httpc, (route && route->pgm) ? route : NULL);
 	}
 
-	/* interactive client: render the login form */
-	return httpcred(httpc);
+	/* a RACF resource gate (RES=) always needs an identity to check against */
+	if (route && route->resclass && mode != HTTP_AUTH_NONE) {
+		need_authn = 1;
+	}
 
-quit:
-	return rc;
+	if (need_authn && !authed) {
+		auth_required_response(httpc, mode);
+		return;
+	}
+
+	/* Stage 2: authorize the resource under the client's ACEE.  Skipped for
+	   AUTH=NONE (a public route has no identity to check -> NONE wins). */
+	if (route && route->resclass && route->resname && authed &&
+	    mode != HTTP_AUTH_NONE) {
+		if (http_check_auth(httpc, route->resclass, route->resname,
+		                    route->resattr) != 0) {
+			forbidden_response(httpc);
+		}
+	}
+}
+
+/*
+** auth_required_response() - the request needs a login but isn't authenticated.
+** The challenge follows the route's AUTH mode:
+**   BASIC   -> 401 + WWW-Authenticate: Basic
+**   FORM    -> the interactive HTML login form
+**   DEFAULT -> legacy heuristic: a client that sent an Authorization header is
+**              a REST/Basic client (401); a browser gets the form.
+** Always ends with httpc->state == CSTATE_DONE so the pipeline stops.
+*/
+static int
+auth_required_response(HTTPC *httpc, UCHAR mode)
+{
+	int	use_basic;
+
+	if (mode == HTTP_AUTH_FORM) {
+		return httpcred(httpc);              /* renders the form, sets DONE */
+	}
+	else if (mode == HTTP_AUTH_BASIC) {
+		use_basic = 1;
+	}
+	else {
+		/* DEFAULT: REST client (sent Authorization) -> 401, else the form */
+		use_basic = (http_get_env(httpc, "HTTP_Authorization") != NULL);
+	}
+
+	if (!use_basic) {
+		return httpcred(httpc);              /* interactive client -> form */
+	}
+
+	http_resp(httpc, 401);
+	http_printf(httpc, "WWW-Authenticate: Basic realm=\"%s\"\r\n",
+	            HTTP_AUTH_REALM);
+	http_printf(httpc, "Cache-Control: no-store\r\n");
+	http_printf(httpc, "Content-Type: text/plain\r\n");
+	http_printf(httpc, "\r\n");
+	http_printf(httpc, "401 Unauthorized\n");
+	httpc->state = CSTATE_DONE;
+	return 0;
+}
+
+/*
+** forbidden_response() - the client is authenticated but the route's RES=
+** resource check denied access.  403 + short body; ends at CSTATE_DONE.
+*/
+static int
+forbidden_response(HTTPC *httpc)
+{
+	http_resp(httpc, 403);
+	http_printf(httpc, "Cache-Control: no-store\r\n");
+	http_printf(httpc, "Content-Type: text/plain\r\n");
+	http_printf(httpc, "\r\n");
+	http_printf(httpc, "403 Forbidden\n");
+	httpc->state = CSTATE_DONE;
+	return 0;
 }

--- a/src/httpprm.c
+++ b/src/httpprm.c
@@ -15,6 +15,7 @@ static void set_defaults(HTTPD *httpd);
 static void parse_line(HTTPD *httpd, char *line);
 static void parse_keyvalue(HTTPD *httpd, const char *key, const char *value);
 static void parse_mod(HTTPD *httpd, const char *value);
+static void parse_loc(HTTPD *httpd, const char *value);
 static void parse_login(HTTPD *httpd, const char *value);
 static void parse_tzoffset(HTTPD *httpd, const char *value);
 static int  do_bind(HTTPD *httpd);
@@ -291,6 +292,9 @@ parse_keyvalue(HTTPD *httpd, const char *key, const char *value)
         wtof("HTTPD410W CGI= is deprecated, use MOD= instead");
         parse_mod(httpd, value);
     }
+    else if (strcmp(key, "LOC") == 0) {
+        parse_loc(httpd, value);
+    }
     else if (strcmp(key, "CLIENT_TIMEOUT_MSG") == 0) {
         if (atoi(value) > 0) httpd->client |= HTTPD_CLIENT_INMSG;
         else                 httpd->client &= ~HTTPD_CLIENT_INMSG;
@@ -358,7 +362,110 @@ parse_keyvalue(HTTPD *httpd, const char *key, const char *value)
 }
 
 /* ====================================================================
-** Parse MOD=PROGRAM [pattern]
+** Per-route auth policy, shared by MOD= (CGI) and LOC= (static prefix).
+** ================================================================= */
+typedef struct {
+    UCHAR   auth;               /* HTTP_AUTH_* (DEFAULT until AUTH= seen)   */
+    UCHAR   resattr;            /* RACF attr (RACF_ATTR_READ when RES= set) */
+    char   *resclass;           /* strdup'd RACF class (NULL = no authz)    */
+    char   *resname;            /* strdup'd RACF resource name              */
+} ROUTE_POLICY;
+
+/* tokenize() - split s in place into whitespace-delimited tokens.  Returns the
+** count, filling tok[0..count) with pointers into s (each NUL-terminated). */
+static int
+tokenize(char *s, char **tok, int max)
+{
+    int n = 0;
+
+    while (*s && n < max) {
+        while (*s == ' ' || *s == '\t') s++;    /* skip leading blanks */
+        if (!*s) break;
+        tok[n++] = s;
+        while (*s && *s != ' ' && *s != '\t') s++;
+        if (*s) *s++ = '\0';                    /* terminate the token */
+    }
+    return n;
+}
+
+/* is_route_kv() - true if tok is a trailing route option (AUTH=.../RES=...)
+** rather than a positional path token. */
+static int
+is_route_kv(const char *tok)
+{
+    return http_cmpn(tok, "AUTH=", 5) == 0 || http_cmpn(tok, "RES=", 4) == 0;
+}
+
+/* parse_kv_tail() - parse the trailing AUTH=/RES= tokens (tok[start..ntok)),
+** shared by parse_mod() and parse_loc().  Unknown tokens are warned + ignored;
+** strdup'd RES= strings are handed to the route by apply_policy(). */
+static void
+parse_kv_tail(HTTPD *httpd, char **tok, int start, int ntok, ROUTE_POLICY *pol)
+{
+    int i;
+
+    for (i = start; i < ntok; i++) {
+        char *t = tok[i];
+
+        if (http_cmpn(t, "AUTH=", 5) == 0) {
+            char *v = t + 5;
+
+            if (http_cmp(v, "NONE") == 0)       pol->auth = HTTP_AUTH_NONE;
+            else if (http_cmp(v, "FORM") == 0)  pol->auth = HTTP_AUTH_FORM;
+            else if (http_cmp(v, "BASIC") == 0) pol->auth = HTTP_AUTH_BASIC;
+            else
+                wtof("HTTPD411W ignoring unknown AUTH mode '%s'", v);
+        }
+        else if (http_cmpn(t, "RES=", 4) == 0) {
+            char *v     = t + 4;                /* class:resource */
+            char *colon = strchr(v, ':');
+
+            if (colon && colon[1]) {
+                *colon = '\0';
+                free(pol->resclass);
+                free(pol->resname);
+                pol->resclass = strdup(v);
+                pol->resname  = strdup(colon + 1);
+                pol->resattr  = RACF_ATTR_READ;
+            }
+            else {
+                wtof("HTTPD412W ignoring malformed RES= '%s' "
+                     "(need class:resource)", v);
+            }
+        }
+        else {
+            wtof("HTTPD413W ignoring unknown route option '%s'", t);
+        }
+    }
+
+    /* AUTH=NONE with a resource is contradictory: a public route has no ACEE
+       to check against.  Warn and let NONE win -- the gate skips authz. */
+    if (pol->auth == HTTP_AUTH_NONE && pol->resclass) {
+        wtof("HTTPD414W AUTH=NONE ignores RES=%s:%s (public route)",
+             pol->resclass, pol->resname);
+    }
+}
+
+/* apply_policy() - move the parsed policy onto a freshly registered route
+** (the strdup'd RES= storage becomes AS-lifetime, like path/pgm), or release
+** it if the route could not be registered. */
+static void
+apply_policy(HTTPCGI *cgi, ROUTE_POLICY *pol)
+{
+    if (cgi) {
+        cgi->auth     = pol->auth;
+        cgi->resattr  = pol->resattr;
+        cgi->resclass = pol->resclass;
+        cgi->resname  = pol->resname;
+    }
+    else {
+        free(pol->resclass);
+        free(pol->resname);
+    }
+}
+
+/* ====================================================================
+** Parse MOD=PROGRAM [pattern] [AUTH=mode] [RES=class:resource]
 ** If pattern is omitted, derive *.<lowercase program> and use DOCROOT.
 ** ================================================================= */
 static void
@@ -366,32 +473,40 @@ parse_mod(HTTPD *httpd, const char *value)
 {
     char  program[9];
     char  auto_pattern[16];
-    char *path;
+    char *tok[8];
     char *tmp;
+    char *path;
+    int   ntok;
+    int   ti;
     int   j;
     int   login = httpd->login & HTTPD_LOGIN_CGI;
+    ROUTE_POLICY pol;
+    HTTPCGI *cgi;
 
     tmp = strdup(value);
     if (!tmp) return;
 
-    /* first token = program name */
-    path = tmp;
-    while (*path && *path != ' ' && *path != '\t')
-        path++;
-    if (*path) {
-        *path = '\0';
-        path++;
-        while (*path == ' ' || *path == '\t')
-            path++;
+    memset(&pol, 0, sizeof(pol));               /* auth = HTTP_AUTH_DEFAULT */
+
+    ntok = tokenize(tmp, tok, 8);
+    if (ntok < 1) {                             /* no program name */
+        free(tmp);
+        return;
     }
 
-    /* fold program name to uppercase, max 8 chars */
-    for (j = 0; j < 8 && tmp[j]; j++)
-        program[j] = (char)toupper((unsigned char)tmp[j]);
+    /* first token = program name, folded to uppercase, max 8 chars */
+    for (j = 0; j < 8 && tok[0][j]; j++)
+        program[j] = (char)toupper((unsigned char)tok[0][j]);
     program[j] = '\0';
 
-    /* no pattern → derive *.<lowercase program> */
-    if (!path[0]) {
+    /* optional second token = path pattern (unless it's already AUTH=/RES=) */
+    ti = 1;
+    if (ti < ntok && !is_route_kv(tok[ti])) {
+        path = tok[ti];
+        ti++;
+    }
+    else {
+        /* no explicit pattern -> derive *.<lowercase program> */
         auto_pattern[0] = '*';
         auto_pattern[1] = '.';
         for (j = 0; j < 8 && program[j]; j++)
@@ -400,13 +515,67 @@ parse_mod(HTTPD *httpd, const char *value)
         path = auto_pattern;
     }
 
+    /* remaining tokens = per-route AUTH=/RES= policy */
+    parse_kv_tail(httpd, tok, ti, ntok, &pol);
+
     if (program[0]) {
-        if (!http_add_cgi(httpd, program, path, login)) {
+        cgi = http_add_cgi(httpd, program, path, login);
+        apply_policy(cgi, &pol);
+        if (!cgi) {
             wtof("HTTPD035W Unable to register module %s for %s",
                  program, path);
         } else {
             wtof("HTTPD036I Module %s registered for %s", program, path);
         }
+    }
+    else {
+        apply_policy(NULL, &pol);               /* release RES= strings */
+    }
+
+    free(tmp);
+}
+
+/* ====================================================================
+** Parse LOC=PATH [AUTH=mode] [RES=class:resource]
+** A program-less route: a static path prefix that carries the same auth
+** policy as MOD= but falls through to httpget (pgm == NULL) instead of
+** dispatching a CGI.  This is what static/SPA deployments need to protect a
+** whole subtree behind a login or a RACF/RAKF profile.
+** ================================================================= */
+static void
+parse_loc(HTTPD *httpd, const char *value)
+{
+    char *tok[8];
+    char *tmp;
+    char *path;
+    int   ntok;
+    ROUTE_POLICY pol;
+    HTTPCGI *cgi;
+
+    tmp = strdup(value);
+    if (!tmp) return;
+
+    memset(&pol, 0, sizeof(pol));               /* auth = HTTP_AUTH_DEFAULT */
+
+    ntok = tokenize(tmp, tok, 8);
+    if (ntok < 1 || is_route_kv(tok[0])) {      /* first token must be a path */
+        wtof("HTTPD415W LOC= requires a path (e.g. LOC /admin/* AUTH=BASIC)");
+        free(tmp);
+        return;
+    }
+
+    path = tok[0];
+
+    /* remaining tokens = per-route AUTH=/RES= policy */
+    parse_kv_tail(httpd, tok, 1, ntok, &pol);
+
+    /* pgm == NULL registers a program-less (static) route */
+    cgi = http_add_cgi(httpd, NULL, path, 0);
+    apply_policy(cgi, &pol);
+    if (!cgi) {
+        wtof("HTTPD416W Unable to register location %s", path);
+    } else {
+        wtof("HTTPD417I Location %s registered", path);
     }
 
     free(tmp);


### PR DESCRIPTION
Implements step 3/6 of the auth redesign (`docs/auth-redesign.md` §2.2, §2.3, §3.1.3): replace the coarse global `LOGIN` bitmask (kept as the default) with a **per-route auth policy**, enforced as a **2-stage gate in the HTTPD pipeline** instead of inside each CGI — so static and CGI routes are protected uniformly.

## Parmlib syntax (`httpprm.c`)

```
MOD=MVSMF /zosmf/*  AUTH=BASIC RES=FACILITY:MVSMF.ACCESS   # CGI route + resource
LOC=/admin/*        AUTH=BASIC RES=FACILITY:HTTPD.ADMIN    # static subtree behind a profile
LOC=/*              AUTH=NONE                              # public (SPA docroot)
```

- **`AUTH=`** is a simple enum `NONE | FORM | BASIC` (no `TOKEN`, no comma-list — the resolver already tries every source; `AUTH=` only selects the *challenge*). A route **without** `AUTH=` inherits the global `LOGIN` default → existing members keep working unchanged.
- **`RES=class:resource`** is an optional RACF/RAKF resource (checked for `READ`). A resource implies authentication.
- **`LOC=`** is a new **program-less** route: a path that carries the same policy but falls through to the static file handler (`pgm == NULL`).
- `parse_mod()` and the new `parse_loc()` share one `tokenize()` + one `parse_kv_tail()` — no copy-paste parser.

## The 2-stage gate (`httppc.c`)

Runs once, uniformly for CGI and static routes, before serving a file or dispatching a CGI:

1. **Authenticate** — the resolver (#96/#97) already set `httpc->cred`. If the route needs an identity and none is present → **401**, challenge per `AUTH` mode (`BASIC` → `WWW-Authenticate: Basic`, `FORM` → the login form, no `AUTH=` → the legacy heuristic).
2. **Authorize** — if the route sets `RES=`, `http_check_auth()` (#99) RACHECKs it under the client's ACEE → **403** on deny.

`/login`, `/logout` and login-page assets (`/login.*`, `/favicon.*` on reads) stay reachable so an `AUTH=FORM` challenge can always render.

## HTTPCGI + NULL-pgm safety

- `struct httpcgi` gains four **appended** fields (`auth`/`resattr`/`resclass`/`resname`). It is heap-allocated and opaque to CGI modules (`httpcgi.h`), so growth is safe; a new `HTTP_AUTH_DEFAULT=0` sentinel is what makes "no `AUTH=` → inherit `LOGIN`" work for calloc'd/existing routes.
- `pgm == NULL` now marks a LOC route. `http_add_cgi()` accepts it, and **every** `->pgm` deref is guarded (the gated dispatch in `httppc.c`, plus the `httpdbug`/`httpdsrv` displays) so a program-less route can never cause an `S33E`/`S0C4`.

## Verification

- `make modules` — clean `cc370` compile under `-Wall -Werror`; all 6 load modules link.
- Design reviewed: fixed a gate return-contract inversion (caller keys off `CSTATE_DONE`, not rc), the `/login` deadlock under explicit modes, and an `AUTH=NONE RES=` inversion (stage 2 now skipped for `NONE`).

Note: the config format is `KEY=VALUE` (the first `=` splits key/value; `AUTH=`/`RES=` sit inside the whitespace-tokenized value), matching the existing `MOD=` syntax in `samplib/httpprm0`. `AUTH=` deviates from the doc's `AUTH=BASIC,TOKEN` sketch per the issue (simple enum). `HTTP_AUTH_DEFAULT` is added beyond the three named modes because the backward-compat clause requires an "unset" sentinel.

Epic #100 step 3/6.

Fixes #98