### PR TITLE
Fix cred_init() NULL-check (test the credkey result, not the function symbol)

### DIFF
--- a/credentials/src/credinit.c
+++ b/credentials/src/credinit.c
@@ -5,7 +5,7 @@ int cred_init(void *salt, unsigned saltlen)
 	BLOWFISH_KEY	*key = credkey();
 	int				rc = 0;
 	
-	if (!credkey) {
+	if (!key) {
 		wtof("%s: unable to allocate WSA for BLOWFISH_KEY", __func__);
 		return -1;
 	}


### PR DESCRIPTION
`cred_init()` stored `credkey()`'s WSA pointer in `key`, then NULL-checked the **function symbol** `credkey` (its address is never NULL) instead of `key` — the guard was dead code (this is the `credinit.c:8: warning: the address of 'credkey' will always evaluate as 'true'`).

If `credkey()` returns NULL (WSA allocation for the Blowfish key failed at init), `cred_init()` fell through and passed a NULL `key` to `blowfish_key_setup()` → NULL deref. The `"unable to allocate WSA for BLOWFISH_KEY"` message confirms the check was meant to test `key`.

One-line fix: `if (!credkey)` → `if (!key)`.

Verified: `make modules` compiles `credentials/src/credinit.c` warning-free; all 6 modules link.

Fixes #106