### PR TITLE
Fix http_get_userid() returning garbage on CGI-invoked requests

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -107,6 +107,23 @@ sources = ["test/tstbody.c", "src/httpbody.c"]
 name = "TSTEXPIRE"
 sources = ["test/tstexpire.c", "credentials/src/credexp.c"]
 
+# credid_enc()/credid_dec() round-trip + flag survival across a repeat read of a
+# stored CRED (issue #109: http_get_userid() garbage on a cache-hit read).
+# blowfish_encrypt/decrypt are crent370 (MVS) -> MVS-only test (test-mvs); the
+# credid_*/cred_* bodies resolve from the [internal] autocall archive.
+[[test]]
+name = "TSTCRED"
+sources = ["test/mvs/tstcred.c"]
+host = false            # blowfish_* are MVS-only (crent370) -> test-mvs
+
+# http_get_userid() end-to-end on a live HTTPC (issue #109): real cred_login()
+# + cache hit + the real HTTPGUID export.  MVS-only (blowfish + RACF SVCs);
+# http_get_userid/credid_/cred_ resolve from the [internal] autocall archive.
+[[test]]
+name = "TSTGUID"
+sources = ["test/mvs/tstguid.c"]
+host = false            # blowfish_* + RACF SVCs are MVS-only -> test-mvs
+
 # http_new_env() / httpnenv() env-block allocation + layout (guards the M9
 # offsetof sizing).  Needs the HTTPV struct via httpd.h, so MVS-only; httpnenv
 # (HTTPNENV) resolves from the [internal] autocall archive.

--- a/src/httpxauth.c
+++ b/src/httpxauth.c
@@ -15,32 +15,43 @@
 #define HTTP_PRIVATE
 #include "httpd.h"
 
-/* http_get_userid() - copy the client's (decrypted) userid into the caller's
-** buffer as a NUL-terminated string.  Returns out on success, or NULL if
-** there is no credential (or no room).  The transient decrypted CREDID also
-** exposes the password, so it is scrubbed before returning. */
+/* http_get_userid() - copy the client's userid into the caller's buffer as a
+** NUL-terminated string.  Returns out on success, or NULL if there is no
+** authenticated credential (or no room).
+**
+** The userid is read straight from the RACF ACEE (aceeuser is a length-
+** prefixed field: byte 0 = length, bytes 1.. = the userid) -- the same
+** RACF-canonical source http_get_acee() consumers already trust.  We do NOT
+** decrypt httpc->cred->id here: the credential's blowfish key lives in
+** per-GRT WSA (credkey()) and is only initialized in httpd's own GRT by
+** cred_init().  A CGI reached through the HTTPX vector runs under its own C
+** runtime / GRT, where that key is still zero, so credid_dec() would decrypt
+** with an all-zero key and return garbage (issue #109). Reading the ACEE
+** needs no key and is therefore correct from any execution context. */
 __asm__("\n&FUNC SETC 'HTTPGUID'");
 #undef http_get_userid
 UCHAR *
 http_get_userid(HTTPC *httpc, UCHAR *out, unsigned outlen)
 {
-    CREDID   id;
-    unsigned n;
+    ACEE     *acee;
+    unsigned  len;
+    unsigned  n;
 
     if (!out || outlen == 0) return NULL;
     out[0] = 0;
 
-    if (!httpc || !httpc->cred) return NULL;
+    if (!httpc || !httpc->cred || !httpc->cred->acee) return NULL;
 
-    credid_dec(&httpc->cred->id, &id);
+    acee = httpc->cred->acee;
+    len  = (unsigned char) acee->aceeuser[0];   /* length-prefixed userid */
+    if (len > 8) len = 8;                        /* userid is at most 8 chars */
+    if (len > outlen - 1) len = outlen - 1;
 
-    /* id.userid is a NUL-terminated 8+0 field; copy it bounded + terminate */
-    for (n = 0; n < outlen - 1 && id.userid[n]; n++) {
-        out[n] = id.userid[n];
+    for (n = 0; n < len; n++) {
+        out[n] = acee->aceeuser[1 + n];
     }
     out[n] = 0;
 
-    memset(&id, 0, sizeof(id));   /* scrub the decrypted userid/password */
     return out;
 }
 

--- a/test/mvs/tstcred.c
+++ b/test/mvs/tstcred.c
@@ -1,0 +1,97 @@
+/* TSTCRED.C
+** Isolation / regression test for issue #109: http_get_userid() returns
+** still-encrypted CREDID.userid bytes on a repeat (cache-hit) read of a
+** stored CRED, while the first (fresh) read decodes correctly.
+**
+** http_get_userid() (src/httpxauth.c) decrypts httpc->cred->id through
+** credid_dec().  cred_find_by_token() hands the SAME cached CRED object back
+** on every repeat request, and nothing in httpd or the credentials package
+** rewrites a stored cred->id after cred_new() stores it -- so a second decrypt
+** of that object must behave exactly like the first.  This test isolates the
+** credential layer from HTTP / RACF to check that invariant directly:
+**
+**   1. build an encrypted CREDID the way cred_login() does
+**      (credid_update() writes plaintext + clears the flag, then
+**       credid_enc() encrypts + sets CREDID_USER_ENCRYPT),
+**   2. store it in a CRED via cred_new() (the cached object),
+**   3. decrypt the SAME stored CRED twice and assert the userid round-trips
+**      both times, and
+**   4. assert the CREDID_USER_ENCRYPT flag survives both reads (credid_dec()
+**      must never mutate its input -- it only writes *out).
+**
+** blowfish_encrypt/decrypt live in crent370, so this is an MVS-only test
+** (make test-mvs), like tstgctx.  It needs no RACF login and no APF auth: it
+** never calls cred_login()/racf_login(), so it runs anywhere cred_init() can
+** build the blowfish key.  The credid_ / cred_ bodies resolve from the
+** [internal] autocall archive, so only this root is listed in project.toml.
+*/
+#include "cred.h"
+#include <mbtcheck.h>
+
+int main(void)
+{
+    CREDID   id;
+    CREDID   out;
+    CRED     *cred;
+    unsigned addr = 0xC0A8017B;   /* 192.168.1.123 */
+    int      rc;
+
+    printf("=== HTTPD credential decrypt (issue #109) tests ===\n");
+
+    /* set up the blowfish key (NULL salt -> the default blowfish_key_setup
+       object code, same as an unconfigured cred_init()) */
+    rc = cred_init(NULL, 0);
+    CHECK(rc == 0, "cred_init() succeeds");
+    if (rc) return mbt_test_summary("TSTCRED");
+
+    /* 1. build the CREDID exactly as cred_login() does: plaintext update
+          (clears the flag) followed by encrypt (sets the flag). */
+    credid_init(&id);
+    credid_update(&id, &addr, (unsigned char *)"IBMUSER", (unsigned char *)"SYS1");
+    CHECK(!(id.userflg & CREDID_USER_ENCRYPT),
+          "flag clear after credid_update (plaintext written)");
+    CHECK(strcmp((char *)id.userid, "IBMUSER") == 0,
+          "userid is plaintext after credid_update");
+
+    credid_enc(&id, &id);
+    CHECK((id.userflg & CREDID_USER_ENCRYPT) != 0,
+          "flag set after credid_enc");
+    CHECK(strcmp((char *)id.userid, "IBMUSER") != 0,
+          "userid is ciphertext after credid_enc");
+
+    /* 2. store it in a CRED -- the object cred_find_by_token() returns on
+          every cache hit (cred_new() copies *id verbatim). */
+    cred = cred_new(&id, NULL, NULL, 0);
+    CHECK(cred != NULL, "cred_new() allocates a CRED");
+    if (!cred) return mbt_test_summary("TSTCRED");
+    CHECK((cred->id.userflg & CREDID_USER_ENCRYPT) != 0,
+          "stored CRED keeps the encrypt flag");
+
+    /* 3. first (fresh) read -- the login-time decode that is known to work */
+    memset(&out, 0, sizeof(out));
+    credid_dec(&cred->id, &out);
+    CHECK(strcmp((char *)out.userid, "IBMUSER") == 0,
+          "read #1 (fresh) decrypts to IBMUSER");
+
+    /* 4. second read of the SAME stored CRED -- the reported cache-hit path.
+          Nothing rewrote cred->id in between, so it must still decrypt. */
+    memset(&out, 0, sizeof(out));
+    credid_dec(&cred->id, &out);
+    CHECK(strcmp((char *)out.userid, "IBMUSER") == 0,
+          "read #2 (cache hit) decrypts to IBMUSER");
+
+    /* 5. the flag must survive both reads (credid_dec() only writes *out) */
+    CHECK((cred->id.userflg & CREDID_USER_ENCRYPT) != 0,
+          "stored CRED still flagged after two decrypts");
+
+    /* diagnostic dumps: on a failing MVS run the stored ciphertext can be
+       eyeballed against mvsMF's fn=userid "hex" field, and the flag byte
+       against the CREDID_USER_ENCRYPT (0x80) hypothesis in the issue. */
+    wtof("TSTCRED: stored userflg=%02X (expect 80)", cred->id.userflg);
+    wtodumpf(cred->id.userid, 9, "TSTCRED stored userid (ciphertext)");
+    wtodumpf(out.userid, 9, "TSTCRED decrypted userid (expect IBMUSER)");
+
+    cred_free(&cred);
+
+    return mbt_test_summary("TSTCRED");
+}

--- a/test/mvs/tstguid.c
+++ b/test/mvs/tstguid.c
@@ -1,0 +1,116 @@
+/* TSTGUID.C
+** Test for http_get_userid() (HTTPGUID, src/httpxauth.c).
+**
+** Issue #109: http_get_userid() returned garbage for a CGI-invoked request.
+** It decrypted httpc->cred->id with credid_dec(), whose blowfish key
+** (credkey()) lives in per-GRT WSA and is only initialized in httpd's own GRT
+** by cred_init().  A CGI reached through the HTTPX vector (e.g. mvsMF) runs
+** under its own C runtime / GRT, where that key is still zero, so credid_dec()
+** decrypted with an all-zero key and returned garbage.  The fix reads the
+** userid from the RACF ACEE (aceeuser) instead -- no key, correct from any
+** execution context.
+**
+** This test drives the real http_get_userid() (HTTP_PRIVATE, like tstgctx):
+**   Path 1 (no RACF): a CRED carrying a fabricated ACEE whose aceeuser holds
+**     "IBMUSER" -> http_get_userid() must return it (twice / repeat read); a
+**     CRED with no ACEE -> NULL (no key path, no garbage).
+**   Path 2 (RACF): the real thing -- cred_login() (which builds a real ACEE),
+**     a repeat cred_login() the credential cache satisfies with the SAME CRED,
+**     and http_get_userid() reads of both.  Skipped (not failed) without APF.
+**
+** MVS-only (RACF SVCs / project headers).  http_get_userid resolves from the
+** [internal] autocall archive, so only this root is listed in project.toml.
+*/
+#define HTTP_PRIVATE
+#include "httpd.h"
+#include <clibauth.h>   /* __autask() -- APF-authorise for racf_login() */
+#include <mbtcheck.h>
+
+/* fabricate an ACEE carrying a length-prefixed userid in aceeuser (byte 0 =
+** length, bytes 1.. = userid), matching what racf_login() produces */
+static void
+fake_acee(ACEE *acee, const char *user)
+{
+    unsigned len = strlen(user);
+
+    memset(acee, 0, sizeof(*acee));
+    if (len > 8) len = 8;
+    acee->aceeuser[0] = (char) len;
+    memcpy(acee->aceeuser + 1, user, len);
+}
+
+int main(void)
+{
+    HTTPC    *httpc;
+    CRED     *cred;
+    CRED     *cred2;
+    ACEE      acee;
+    unsigned char buf[64];
+    unsigned char *ret;
+    unsigned addr = 0xC0A8017B;   /* 192.168.1.123 */
+    int      apf;
+
+    printf("=== HTTPD http_get_userid (issue #109) tests ===\n");
+
+    httpc = (HTTPC *) calloc(sizeof(HTTPC), 1);
+    CHECK(httpc != NULL, "HTTPC allocated");
+    if (!httpc) return mbt_test_summary("TSTGUID");
+    httpc->addr = addr;
+
+    /* --- Path 1: CRED with a fabricated ACEE (no RACF), real http_get_userid */
+    fake_acee(&acee, "IBMUSER");
+    cred = cred_new(NULL, NULL, &acee, CRED_FLAG_KEEP_ACEE);
+    CHECK(cred != NULL, "cred_new (fabricated ACEE) allocates a CRED");
+    if (cred) {
+        httpc->cred = cred;
+
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_userid(httpc, buf, sizeof(buf));
+        CHECK(ret != NULL, "http_get_userid returns non-NULL (ACEE present)");
+        CHECK(strcmp((char *)buf, "IBMUSER") == 0,
+              "http_get_userid == IBMUSER (from ACEE, read #1)");
+
+        memset(buf, 0, sizeof(buf));
+        http_get_userid(httpc, buf, sizeof(buf));
+        CHECK(strcmp((char *)buf, "IBMUSER") == 0,
+              "http_get_userid == IBMUSER (from ACEE, read #2 / repeat)");
+
+        /* no ACEE -> NULL, and the output buffer is left empty (not garbage) */
+        cred->acee = NULL;
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_userid(httpc, buf, sizeof(buf));
+        CHECK(ret == NULL, "http_get_userid returns NULL when the CRED has no ACEE");
+        CHECK(buf[0] == 0, "output buffer stays empty (NUL) when unauthenticated");
+    }
+
+    /* --- Path 2: real cred_login() + cache hit, real http_get_userid() ---- */
+    apf = __autask();       /* APF-authorise this task for racf_login()       */
+    wtof("TSTGUID: __autask() rc=%d", apf);
+    if (apf != 0) {
+        printf("  SKIP: no APF (rc=%d) -> RACF cred_login path skipped\n", apf);
+        return mbt_test_summary("TSTGUID");
+    }
+
+    cred = cred_login(addr, (unsigned char *)"IBMUSER", (unsigned char *)"SYS1");
+    CHECK(cred != NULL, "cred_login #1 (fresh) succeeds");
+    if (cred) {
+        httpc->cred = cred;
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_userid(httpc, buf, sizeof(buf));
+        CHECK(ret != NULL && strcmp((char *)buf, "IBMUSER") == 0,
+              "http_get_userid == IBMUSER (cred_login fresh read)");
+
+        cred2 = cred_login(addr, (unsigned char *)"IBMUSER", (unsigned char *)"SYS1");
+        CHECK(cred2 != NULL, "cred_login #2 (cache hit) succeeds");
+        CHECK(cred2 == cred, "cache hit returns the SAME cached CRED object");
+        if (cred2) {
+            httpc->cred = cred2;
+            memset(buf, 0, sizeof(buf));
+            ret = http_get_userid(httpc, buf, sizeof(buf));
+            CHECK(ret != NULL && strcmp((char *)buf, "IBMUSER") == 0,
+                  "http_get_userid == IBMUSER (CACHE-HIT read -- the #109 repro)");
+        }
+    }
+
+    return mbt_test_summary("TSTGUID");
+}


### PR DESCRIPTION
Fixes #109

## Root cause (confirmed live on MVS)

`http_get_userid()` decrypted `httpc->cred->id` via `credid_dec()`, whose
blowfish key (`credkey()`) lives in **per-GRT WSA** and is initialized only in
httpd's own GRT by `cred_init()`. A CGI reached through the HTTPX vector (mvsMF)
runs under its **own C runtime / GRT**, where that key is still zero — so
`credid_dec()` decrypted with an all-zero key and returned garbage.

Proven with temporary instrumentation on the live server (encrypt vs decrypt
context):

```
DBGENC grt=00094CF8 key=00124F98 kb=06C869B67997BE14 flg=80   (httpd worker)
DBGDEC grt=001249C8 key=00204F98 kb=0000000000000000 flg=80   (mvsMF CGI)
```

Same ciphertext, flag set, but a **different, uninitialized key** in the CGI's
GRT (the GRT varied per request). This is why `http_get_acee()` (raw pointer)
and httpd's own `credid_dec()` callers (SMF, console, login WTO — all in httpd's
GRT) were unaffected, and why an in-module unit test could not reproduce it.

## Fix

Read the userid straight from the RACF **ACEE** (`aceeuser`, length-prefixed) —
the RACF-canonical identity, **no key needed**, correct from any execution
context, and the same field `http_get_acee()` consumers already read. The
CREDID encryption (which protects the password held in the in-memory credential
cache) is untouched.

## Verification

- `curl -u ibmuser:sys1 .../zosmf/test?fn=userid` → `IBMUSER` (fresh **and**
  cache-hit); wrong password still `401`.
- `make test-mvs`: **TSTGUID** (real `http_get_userid()` over a fabricated-ACEE
  CRED + a real `cred_login()`+cache-hit path) and **TSTCRED** (credid
  encrypt/decrypt round-trip + flag invariant) both pass.

## Note

`http_get_userid()` stays in the HTTPX vector (append-only ABI; already consumed
by mvsMF `jobsapi.c`) — it is now a thin, layout-independent wrapper over the
ACEE userid. The per-GRT `credkey()` limitation is inherent to the credentials
package and only ever affected this one CGI-context decrypt path, which this
change removes.