### PR TITLE
Add http_get_password() HTTPX export for token-safe CGI job submit

### DIFF
--- a/docs/auth-redesign.md
+++ b/docs/auth-redesign.md
@@ -173,6 +173,8 @@ CREDTOK *http_get_token(HTTPC *);                /* the session token       */
 int      http_logout(HTTPC *);                   /* credtok_logout()        */
 int      http_check_auth(HTTPC *, const char *class,
                          const char *resource, int attr);  /* racf_auth     */
+UCHAR   *http_get_password(HTTPC *, UCHAR *out, unsigned outlen);
+                                                 /* decrypted pw (INTRDR)   */
 ```
 
 Then mvsMF **deletes `authmw.c`**: httpd has already resolved `httpc->cred`

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -151,7 +151,8 @@ struct httpd {
     UCHAR       cfg_keepalive_timeout; /* 134 keepalive idle secs   */
     UCHAR       cfg_keepalive_max;  /* 135 max reqs per connection  */
     USHRT       cfg_session_timeout; /* 136 credential idle TTL (min), 0=off */
-};                                  /* 138                          */
+    CREDKEY     *credkey;           /* 138 blowfish key ptr (issue #111) */
+};                                  /* 13C                          */
 
 /* HTTP variables */
 struct httpv {
@@ -442,6 +443,8 @@ struct httpx {
                                     /* 134 RACF resource check      */
     int         (*http_logout)(HTTPC *);
                                     /* 138 end client session       */
+    UCHAR *     (*http_get_password)(HTTPC *, UCHAR *out, unsigned outlen);
+                                    /* 13C client password into buf */
 };
 
 extern int http_in(HTTPC*)                                              asm("HTTPIN");
@@ -512,6 +515,7 @@ extern int http_get_token(HTTPC *, UCHAR *out, unsigned outlen)            asm("
 extern int http_check_auth(HTTPC *, const char *classname,
                            const char *resource, int attr)                asm("HTTPCKAU");
 extern int http_logout(HTTPC *)                                           asm("HTTPLOUT");
+extern UCHAR *http_get_password(HTTPC *, UCHAR *out, unsigned outlen)      asm("HTTPGPWD");
 extern double httpsecs(double *psecs)									asm("HTTPSECS");
 extern int httpcred(HTTPC *httpc)										asm("HTTPCRED");
 extern int httpd048(HTTPD *httpd)										asm("HTTPD048");
@@ -755,6 +759,9 @@ extern int http_gets(HTTPC *httpc, UCHAR *buf, unsigned max)            asm("HTT
 
 #define http_logout(httpc) \
     ((httpx->http_logout)((httpc)))
+
+#define http_get_password(httpc,out,outlen) \
+    ((httpx->http_get_password)((httpc),(out),(outlen)))
 
 #endif  /* ifndef HTTPX_H */
 

--- a/project.toml
+++ b/project.toml
@@ -124,6 +124,15 @@ name = "TSTGUID"
 sources = ["test/mvs/tstguid.c"]
 host = false            # blowfish_* + RACF SVCs are MVS-only -> test-mvs
 
+# http_get_password() end-to-end on a live HTTPC (issue #111): decrypts the
+# caller's password from httpc->cred->id via the key pointer cached in the HTTPD
+# block, for the JES2 INTRDR job-card use case.  MVS-only (blowfish + RACF SVCs);
+# http_get_password/credid_/cred_ resolve from the [internal] autocall archive.
+[[test]]
+name = "TSTGPWD"
+sources = ["test/mvs/tstgpwd.c"]
+host = false            # blowfish_* + RACF SVCs are MVS-only -> test-mvs
+
 # http_new_env() / httpnenv() env-block allocation + layout (guards the M9
 # offsetof sizing).  Needs the HTTPV struct via httpd.h, so MVS-only; httpnenv
 # (HTTPNENV) resolves from the [internal] autocall archive.

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -174,6 +174,14 @@ quit:
 		wtof("HTTPD047E Unable to initialize server credential key, rc=%d", rc);
 	}
 
+	/* Cache the blowfish key pointer in the HTTPD block so CGI-context code
+	   (http_get_password) can reach it without credkey()/__wsaget(), which
+	   only read the key from httpd's own GRT.  cred_init() runs here in that
+	   GRT, so credkey() is valid; the key bytes live at a stable WSA address
+	   readable across the shared address space, so caching the pointer (no
+	   copy) is enough for a CGI running under its own GRT (issue #111). */
+	httpd->credkey = credkey();
+
     /* unlock the httpd */
     unlock(httpd,0);
 

--- a/src/httpx.c
+++ b/src/httpx.c
@@ -84,6 +84,7 @@ static HTTPX vect = {
     http_get_token,             /* 130 http_get_token()             */
     http_check_auth,            /* 134 http_check_auth()            */
     http_logout,                /* 138 http_logout()                */
+    http_get_password,          /* 13C http_get_password()          */
 };
 
 HTTPX *httpx = &vect;

--- a/src/httpxauth.c
+++ b/src/httpxauth.c
@@ -6,7 +6,7 @@
 ** All accessors are NULL-credential safe (an unauthenticated request has
 ** httpc->cred == NULL).  Exported through the HTTPX vector (append-only):
 **   http_get_userid  http_get_acee  http_get_token  http_check_auth
-**   http_logout
+**   http_logout  http_get_password
 **
 ** Each function carries a >8-char C name, so it needs an explicit &FUNC CSECT
 ** name (matching its asm() alias) and an #undef to shed the httpx macro layer
@@ -110,4 +110,68 @@ http_logout(HTTPC *httpc)
     rc = credtok_logout(&httpc->cred->token);
     httpc->cred = NULL;   /* the CRED it pointed at may now be freed */
     return rc;
+}
+
+/* http_get_password() - copy the caller's plaintext password into out as a
+** NUL-terminated string.  Returns out on success, or NULL if the request is
+** unauthenticated (httpc->cred == NULL) or the credential carries no password
+** (e.g. a session ever established purely from a token, with no prior
+** password login) or there is no room in out.
+**
+** Unlike http_get_userid(), the password is NOT in the ACEE -- it lives only
+** in the credential, blowfish-encrypted in httpc->cred->id.password (see
+** cred_login() -> credid_enc()).  cred_login() upper-cases the password before
+** encrypting (RACF folds it anyway), so what is returned here is the RACF-
+** canonical (upper-case) form -- correct for a JOB card, but note it is not
+** necessarily byte-for-byte what the client typed.
+**
+** We decrypt with blowfish_decrypt(), which takes the key EXPLICITLY and so is
+** a pure function of (data, key) valid in any GRT.  We must NOT call credkey()/
+** __wsaget(): those read the key from the *current* GRT's WSA, which is only
+** initialized in httpd's own GRT by cred_init().  A CGI reached through the
+** HTTPX vector runs under its own GRT, where that slot is still zero, so the
+** key would read back as garbage (issue #109/#111).  Instead we use the key
+** pointer httpd cached in the HTTPD block at cred_init() time -- the key bytes
+** live at a stable WSA address readable across the shared address space, so the
+** cached pointer works from any execution context.
+**
+** Security: for job submission the CGI unavoidably needs the plaintext password
+** to write it onto the JOB card.  The caller should memset() its buffer as soon
+** as the JOB card is built. */
+__asm__("\n&FUNC SETC 'HTTPGPWD'");
+#undef http_get_password
+UCHAR *
+http_get_password(HTTPC *httpc, UCHAR *out, unsigned outlen)
+{
+    CREDKEY  *key;
+    UCHAR     plain[8];             /* one blowfish block = the password */
+    unsigned  len;
+    unsigned  n;
+
+    if (!out || outlen == 0) return NULL;
+    out[0] = 0;
+
+    if (!httpc || !httpc->cred || !httpc->httpd) return NULL;
+
+    /* no password on this credential (e.g. a token-only session) */
+    if (!(httpc->cred->id.passflg & CREDID_PASS_ENCRYPT)) return NULL;
+
+    /* GRT-independent key pointer cached by cred_init() -- never credkey() */
+    key = httpc->httpd->credkey;
+    if (!key) return NULL;
+
+    /* one 8-byte block; plaintext is NUL-padded when shorter than 8 chars */
+    blowfish_decrypt(httpc->cred->id.password, plain, key);
+
+    for (len = 0; len < sizeof(plain) && plain[len]; len++) ;
+    if (len > outlen - 1) len = outlen - 1;
+
+    for (n = 0; n < len; n++) {
+        out[n] = plain[n];
+    }
+    out[n] = 0;
+
+    memset(plain, 0, sizeof(plain));   /* scrub the local plaintext copy */
+
+    return out;
 }

--- a/test/mvs/tstgpwd.c
+++ b/test/mvs/tstgpwd.c
@@ -1,0 +1,177 @@
+/* TSTGPWD.C
+** Test for http_get_password() (HTTPGPWD, src/httpxauth.c).
+**
+** Issue #111: a CGI (mvsMF) submitting a batch job through the JES2 internal
+** reader needs the caller's plaintext password for the JOB card, for both
+** Basic and token auth.  The password is retained (blowfish-encrypted) in
+** httpc->cred->id.password, but a CGI cannot decrypt it with credid_dec():
+** that reads the blowfish key via credkey()/__wsaget() from the current GRT's
+** WSA, which is only initialized in httpd's own GRT by cred_init() (the #109
+** wall).  http_get_password() instead uses the key pointer httpd caches in the
+** HTTPD block (httpd->credkey) and blowfish_decrypt()s directly -- a pure
+** function of (data, key) valid from any execution context.
+**
+** This test drives the real http_get_password() (HTTP_PRIVATE, like tstguid):
+**   Path 1 (no RACF): a CRED carrying an encrypted CREDID built the way
+**     cred_login() does (credid_update() plaintext + credid_enc()); the HTTPD
+**     block caches credkey() as httpd does at cred_init() time.
+**       - a 4-char and an exactly-8-char password each round-trip (twice /
+**         repeat read, mirroring a cache hit);
+**       - a CRED with no password (passflg clear) -> NULL;
+**       - no CRED / a NULL cached key -> NULL, output buffer left empty.
+**   Path 2 (RACF): the real thing -- cred_login() with a lower-case password
+**     that RACF folds to upper case, then http_get_password() must return the
+**     folded (upper-case) form.  Skipped (not failed) without APF.
+**
+** MVS-only (blowfish + RACF SVCs / project headers).  http_get_password /
+** credid_ / cred_ resolve from the [internal] autocall archive, so only this
+** root is listed in project.toml.
+*/
+#define HTTP_PRIVATE
+#include "httpd.h"
+#include <clibauth.h>   /* __autask() -- APF-authorise for racf_login() */
+#include <mbtcheck.h>
+
+/* build an encrypted CREDID exactly as cred_login() does: plaintext update
+** (writes verbatim, clears the flag) followed by encrypt (sets the flag). */
+static void
+enc_cred(CREDID *id, unsigned addr, const char *pass)
+{
+    credid_init(id);
+    credid_update(id, &addr, (unsigned char *)"IBMUSER", (unsigned char *)pass);
+    credid_enc(id, id);
+}
+
+int main(void)
+{
+    HTTPD    *httpd;
+    HTTPC    *httpc;
+    CRED     *cred;
+    CRED     *cred2;
+    CREDID    id;
+    unsigned char buf[64];
+    unsigned char *ret;
+    unsigned addr = 0xC0A8017B;   /* 192.168.1.123 */
+    int      rc;
+    int      apf;
+
+    printf("=== HTTPD http_get_password (issue #111) tests ===\n");
+
+    /* set up the blowfish key (NULL salt -> default, like an unconfigured
+       cred_init()); credkey() is valid here in the test's own GRT. */
+    rc = cred_init(NULL, 0);
+    CHECK(rc == 0, "cred_init() succeeds");
+    if (rc) return mbt_test_summary("TSTGPWD");
+
+    httpd = (HTTPD *) calloc(1, sizeof(HTTPD));
+    httpc = (HTTPC *) calloc(1, sizeof(HTTPC));
+    CHECK(httpd != NULL && httpc != NULL, "HTTPD + HTTPC allocated");
+    if (!httpd || !httpc) return mbt_test_summary("TSTGPWD");
+
+    /* httpd caches the blowfish key pointer at cred_init() time -- the value
+       http_get_password() reads instead of calling credkey() from CGI ctx. */
+    httpd->credkey = credkey();
+    CHECK(httpd->credkey != NULL, "httpd->credkey cached (non-NULL)");
+    httpc->httpd = httpd;
+    httpc->addr  = addr;
+
+    /* --- Path 1a: 4-char password, no RACF ------------------------------- */
+    enc_cred(&id, addr, "SYS1");
+    cred = cred_new(&id, NULL, NULL, 0);
+    CHECK(cred != NULL, "cred_new (encrypted 4-char pass) allocates a CRED");
+    if (cred) {
+        httpc->cred = cred;
+
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_password(httpc, buf, sizeof(buf));
+        CHECK(ret != NULL, "http_get_password returns non-NULL (pass present)");
+        CHECK(strcmp((char *)buf, "SYS1") == 0,
+              "http_get_password == SYS1 (read #1)");
+
+        memset(buf, 0, sizeof(buf));
+        http_get_password(httpc, buf, sizeof(buf));
+        CHECK(strcmp((char *)buf, "SYS1") == 0,
+              "http_get_password == SYS1 (read #2 / repeat, cache-hit shape)");
+
+        cred_free(&cred);
+    }
+
+    /* --- Path 1b: exactly-8-char password (no NUL inside the block) ------- */
+    enc_cred(&id, addr, "PASSWRD8");
+    cred = cred_new(&id, NULL, NULL, 0);
+    CHECK(cred != NULL, "cred_new (encrypted 8-char pass) allocates a CRED");
+    if (cred) {
+        httpc->cred = cred;
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_password(httpc, buf, sizeof(buf));
+        CHECK(ret != NULL && strcmp((char *)buf, "PASSWRD8") == 0,
+              "http_get_password == PASSWRD8 (full 8-char block round-trips)");
+        cred_free(&cred);
+    }
+
+    /* --- Path 1c: CRED with no password (passflg clear) -> NULL ---------- */
+    credid_init(&id);                       /* all-zero: flag clear, no pass */
+    cred = cred_new(&id, NULL, NULL, 0);
+    CHECK(cred != NULL, "cred_new (no password) allocates a CRED");
+    if (cred) {
+        httpc->cred = cred;
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_password(httpc, buf, sizeof(buf));
+        CHECK(ret == NULL, "http_get_password NULL when CRED has no password");
+        CHECK(buf[0] == 0, "output buffer stays empty (NUL) for no password");
+        cred_free(&cred);
+    }
+
+    /* --- Path 1d: no CRED at all -> NULL --------------------------------- */
+    httpc->cred = NULL;
+    memset(buf, 0, sizeof(buf));
+    ret = http_get_password(httpc, buf, sizeof(buf));
+    CHECK(ret == NULL, "http_get_password NULL when unauthenticated (no CRED)");
+    CHECK(buf[0] == 0, "output buffer stays empty (NUL) when unauthenticated");
+
+    /* --- Path 1e: a NULL cached key -> NULL (never falls back to garbage) - */
+    enc_cred(&id, addr, "SYS1");
+    cred = cred_new(&id, NULL, NULL, 0);
+    if (cred) {
+        httpc->cred     = cred;
+        httpd->credkey  = NULL;             /* simulate an un-cached key     */
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_password(httpc, buf, sizeof(buf));
+        CHECK(ret == NULL, "http_get_password NULL when no cached key");
+        CHECK(buf[0] == 0, "output buffer stays empty (NUL) with no key");
+        httpd->credkey  = credkey();        /* restore for Path 2            */
+        cred_free(&cred);
+    }
+
+    /* --- Path 2: real cred_login() folds the password to upper case ------ */
+    apf = __autask();       /* APF-authorise this task for racf_login()       */
+    wtof("TSTGPWD: __autask() rc=%d", apf);
+    if (apf != 0) {
+        printf("  SKIP: no APF (rc=%d) -> RACF cred_login path skipped\n", apf);
+        return mbt_test_summary("TSTGPWD");
+    }
+
+    /* pass a lower-case password: cred_login() upper-cases it before both
+       racf_login() and encryption, so http_get_password() must return "SYS1". */
+    cred = cred_login(addr, (unsigned char *)"IBMUSER", (unsigned char *)"sys1");
+    CHECK(cred != NULL, "cred_login #1 (fresh) succeeds");
+    if (cred) {
+        httpc->cred = cred;
+        memset(buf, 0, sizeof(buf));
+        ret = http_get_password(httpc, buf, sizeof(buf));
+        CHECK(ret != NULL && strcmp((char *)buf, "SYS1") == 0,
+              "http_get_password == SYS1 (RACF-folded upper case, fresh read)");
+
+        cred2 = cred_login(addr, (unsigned char *)"IBMUSER", (unsigned char *)"sys1");
+        CHECK(cred2 == cred, "cred_login #2 returns the SAME cached CRED");
+        if (cred2) {
+            httpc->cred = cred2;
+            memset(buf, 0, sizeof(buf));
+            ret = http_get_password(httpc, buf, sizeof(buf));
+            CHECK(ret != NULL && strcmp((char *)buf, "SYS1") == 0,
+                  "http_get_password == SYS1 (cache-hit read)");
+        }
+    }
+
+    return mbt_test_summary("TSTGPWD");
+}


### PR DESCRIPTION
Fixes #111

## Summary

Adds an append-only HTTPX export, `http_get_password()`, so a CGI (mvsMF) can obtain the caller's plaintext password to place a real `USER=`/`PASSWORD=` on a JES2 internal-reader JOB card — for **both** Basic and token authentication.

The password is already retained server-side: `cred_login()` Blowfish-encrypts it into the persistent `CRED` (`id.password`) for the credential's whole lifetime, and a token request resolves to the same `CRED` via `cred_find_by_token()`. A CGI cannot decrypt it directly because `credid_dec()` reads the Blowfish key via `credkey()`/`__wsaget()` from the **current GRT's WSA**, which is only initialized in httpd's own GRT — a CGI runs under its own GRT where that key reads back as zero (the #109 wall).

## Changes

- **`include/httpd.h`** — new `CREDKEY *credkey` field appended to the `HTTPD` block (0x138); new `http_get_password` function pointer appended to the `HTTPX` vector (0x13C, append-only); extern prototype + public macro.
- **`src/httpd.c`** — cache `credkey()` into `httpd->credkey` right after `cred_init()` (runs in httpd's GRT, where `credkey()` is valid).
- **`src/httpxauth.c`** — implement `http_get_password()`. It reads the **cached key pointer** (never `credkey()`/`__wsaget()`) and `blowfish_decrypt()`s `httpc->cred->id.password` — a pure function of (data, key) valid in any GRT.
- **`src/httpx.c`** — wire the new entry into the static vector.
- **`docs/auth-redesign.md`** — add the export to the §2.4 list.

## Behavior

- NULL-safe like the sibling accessors: returns `NULL` when unauthenticated (`httpc->cred == NULL`), when the credential carries no password (token-only session, `passflg` without `CREDID_PASS_ENCRYPT`), or when there is no room in `out`.
- Returned password is the RACF-canonical (upper-cased) form, since `cred_login()` folds it before encrypting — correct for a JOB card.

## Security

For job submission the plaintext password is unavoidably needed by the CGI (it goes on the JOB card), so the "never hand back the decrypted password" principle can't hold here. The mitigation is to keep the **key** encapsulated in httpd (the CGI only receives the already-required plaintext) and have the caller `memset` its buffer immediately after building the JOB card. This is no more exposure than the current Basic-header decode, and it finally covers the token flow.

## Verification

- `make compiledb` regenerated cleanly (120 entries); no new clangd diagnostics in the changed code (the remaining httpd.c/httpd.h clangd errors are pre-existing trigraph/MVS-builtin artifacts unrelated to this change).
- The GRT-crossing behavior (a CGI decrypting with the cached pointer) cannot be exercised on the host — it needs live MVS via the mvsMF consumer (mvslovers/mvsmf#164).

## Consumer

Once merged, mvsMF's `process_jobcard()` sources `PASSWORD=` from `http_get_password()` and the userid from `http_get_userid()`, drops `get_basic_auth_credentials()`, and stops parsing the `Authorization` header — job submit then works identically for Basic and token auth (mvslovers/mvsmf#164).