### PR TITLE
Stop logging the plaintext password on a failed login

### DIFF
--- a/credentials/src/credlin.c
+++ b/credentials/src/credlin.c
@@ -65,11 +65,12 @@ cred_login(unsigned addr, unsigned char *userid, unsigned char *password)
 	cred = cred_find_by_token(&tok);
 	if (cred) goto cleanup;
 
-	/* attempt to login via racf interface */
+	/* attempt to login via racf interface.  On failure RAKF already writes its
+	   own RAKF0004 audit message, so we do NOT log here -- an httpd message
+	   would only duplicate it, and logging the attempted password (pass) would
+	   leak a plaintext credential to the console/SYSLOG (issue #116). */
 	acee = racf_login(user, pass, 0, &rc);
 	if (!acee) {
-		wtof("%s: racf_login(\"%s\", \"%s\") failed, rc=%d", 
-			__func__, user, pass, rc);
 		goto cleanup;
 	}
 


### PR DESCRIPTION
Fixes #116

## Problem

`cred_login()` logged a failed `racf_login()` with the **attempted password in plaintext** to the operator console and SYSLOG:

```
RAKF0004 INVALID ATTEMPT TO ACCESS SYSTEM:  USER:NOSUCHUS~
cred_login: racf_login("NOSUCHUS", "WRONGPW") failed, rc=28
```

Two issues: it **duplicates** RAKF's own `RAKF0004` audit message, and it **leaks a plaintext credential** (on a typo that is the real password; probing bots spam the log). This contradicts the package's posture of keeping the password Blowfish-encrypted at rest (#96/#97/#99).

## Fix

Remove the `wtof` at `credlin.c:71-72` (Option A). `RAKF0004` provides the audit trail; the `rc` is still returned to the caller (`resolve_credential` → `cred==NULL` → 401). `rc` remains used by the later `array_add` path, so no unused-variable warning.

## Scope / audit

Audited the rest of the credential package: this is the **only** active log that was duplicate/sensitive. The other `credlin.c`/`credinit.c`/`credfrea.c` messages are rare non-sensitive error diagnostics (kept), and the `httpcred.c` `process_*()` traces are already `#if 0`-disabled. The `HTTPD007I/008I/008W` login/logout audit lines log userid+IP only (no password) and are kept.

## Verification

One-line deletion inside an existing `if` block; no logic change. clangd shows no new diagnostics; CI builds the credential package under the real cc370 `-Werror`.