### PR TITLE
Suppress Basic challenge on z/OSMF API 401s for XHR clients (#119)

### DIFF
--- a/samplib/httpprm0
+++ b/samplib/httpprm0
@@ -47,6 +47,12 @@
 #                                     e.g. MOD=LUA → *.lua, MOD=REXX → *.rexx)
 #         any MOD= may add trailing  AUTH=mode  and/or  RES=class:resource
 #
+# Public z/OSMF endpoints must precede the gated /zosmf/* catch-all (first
+# match wins): the anonymous reachability probe (/zosmf/info) and the token
+# login/logout endpoint (/zosmf/services/authenticate) do their own auth, so
+# the gate must not challenge them.
+MOD=MVSMF /zosmf/info                    AUTH=NONE
+MOD=MVSMF /zosmf/services/authenticate   AUTH=NONE
 MOD=MVSMF /zosmf/*
 # MOD=MVSMF /zosmf/*  AUTH=BASIC RES=FACILITY:MVSMF.ACCESS  (protected API)
 # MOD=HTTPDSRV /.dsrv  AUTH=FORM                             (browser login)

--- a/src/httppc.c
+++ b/src/httppc.c
@@ -387,7 +387,8 @@ auth_gate(HTTPC *httpc, HTTPCGI *route)
 /*
 ** auth_required_response() - the request needs a login but isn't authenticated.
 ** The challenge follows the route's AUTH mode:
-**   BASIC   -> 401 + WWW-Authenticate: Basic
+**   BASIC   -> 401 + WWW-Authenticate: Basic (suppressed for XHR clients that
+**              send the z/OSMF CSRF marker -- see the emit below)
 **   FORM    -> the interactive HTML login form
 **   DEFAULT -> legacy heuristic: a client that sent an Authorization header is
 **              a REST/Basic client (401); a browser gets the form.
@@ -414,8 +415,17 @@ auth_required_response(HTTPC *httpc, UCHAR mode)
 	}
 
 	http_resp(httpc, 401);
-	http_printf(httpc, "WWW-Authenticate: Basic realm=\"%s\"\r\n",
-	            HTTP_AUTH_REALM);
+	/* Omit the Basic challenge for XHR/API clients that identify via the
+	   z/OSMF CSRF marker.  A WWW-Authenticate makes the browser pop its native
+	   credential dialog, and the Basic credentials it then caches outlive the
+	   token session -- defeating token logout (#119).  A challenge-less 401
+	   lets the SPA's own "session expired" handling see the 401.  Genuine
+	   Basic clients (curl -u, Zowe) send credentials preemptively and do not
+	   need the challenge; a plain browser navigation (no marker) still gets it. */
+	if (http_get_env(httpc, "HTTP_X-CSRF-ZOSMF-HEADER") == NULL) {
+		http_printf(httpc, "WWW-Authenticate: Basic realm=\"%s\"\r\n",
+		            HTTP_AUTH_REALM);
+	}
 	http_printf(httpc, "Cache-Control: no-store\r\n");
 	http_printf(httpc, "Content-Type: text/plain\r\n");
 	http_printf(httpc, "\r\n");


### PR DESCRIPTION
## Problem

httpd returned `WWW-Authenticate: Basic realm="MVS"` on **every** 401, including XHR/`fetch` calls from the mvsMF SPA. Browsers respond to that header by popping their native credential dialog, and the Basic credentials the browser then caches:

1. shadow the SPA's own 401 handling (the dialog intercepts before the JS sees the 401), and
2. **outlive the token session** — they survive the SPA's token logout (`DELETE /zosmf/services/authenticate`), re-introducing browser-side Basic credentials and defeating the token model from mvslovers/mvsmf#161.

## Change

`src/httppc.c` (`auth_required_response`): omit the `WWW-Authenticate` line when the request carries the z/OSMF CSRF marker `X-CSRF-ZOSMF-HEADER`. Such clients are programmatic/XHR and handle the bare 401 themselves. The rest of the 401 (status, `Cache-Control: no-store`, body) is unchanged.

- Genuine Basic clients (`curl -u`, Zowe) send credentials preemptively and never needed the challenge.
- A plain browser navigation with no marker still receives the challenge (e.g. a static `AUTH=BASIC` area keeps its intended popup).
- `FORM` routes are untouched.

The env lookup is caseless (`http_find_env` → `http_cmp`), so the marker matches regardless of header casing.

## Sample parmlib

`samplib/httpprm0`: add two exact `AUTH=NONE` routes **before** the gated `/zosmf/*` catch-all (first match wins):

- `/zosmf/info` — the SPA's anonymous reachability probe gets a clean 200.
- `/zosmf/services/authenticate` — the token login/logout endpoint does its own auth; the gate must not challenge it.

## Design note

This does **not** mirror stock z/OSMF — verified empirically that real z/OSMF *does* send `WWW-Authenticate: Basic` on its REST API 401s (and ignores `X-CSRF-ZOSMF-HEADER`). This is a deliberate improvement for our token-based SPA, not a compatibility claim.

The cleaner long-term model — separating *credential source* (accept Basic) from *challenge presentation* (advertise Basic) via a per-route API marker — is filed as a follow-up under the auth-redesign cleanup (#105).

## Verification

- Host compile of `src/httppc.c` with `cc370 -S` clean (no warnings on the changed file); the `HTTP_X-CSRF-ZOSMF-HEADER` literal confirmed present in the generated assembly.
- `make compiledb` regenerated (122 entries).

## To verify on the live MVS system

- With `X-CSRF-ZOSMF-HEADER` present, a `/zosmf/*` 401 returns **no** `WWW-Authenticate` (bare 401); without it, the challenge is still sent.
- Confirm the mvsMF SPA no longer pops the native dialog on token expiry, and that Basic credentials no longer survive token logout.

Fixes #119