### PR TITLE
Migrate to the new jesprint() signature (callback arg + JESPRST)

### DIFF
--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -644,12 +644,15 @@ quit:
     return rc;
 }
 
-static int do_print_sysout_line(const char *line, unsigned linelen);
+static int do_print_sysout_line(const char *line, unsigned linelen, void *arg);
+static const char *do_print_sysout_why(const JESPRST *st);
 __asm__("\n&FUNC    SETC 'do_print_sysout'");
 static int
 do_print_sysout(HTTPD *httpd, HTTPC *httpc, JES *jes, JESJOB *job, unsigned **dsid)
 {
     int         rc  = 0;
+    const char  *why;
+    JESPRST     st;
     unsigned    count;
     unsigned    n;
 
@@ -667,8 +670,15 @@ do_print_sysout(HTTPD *httpd, HTTPC *httpc, JES *jes, JESJOB *job, unsigned **ds
 
         if ((dd->flag & FLAG_SYSIN) && !dsid) continue;   /* don't show SYSIN data        */
 
-        rc = jesprint(jes, job, dd->dsid, do_print_sysout_line);
+        rc = jesprint(jes, job, dd->dsid, do_print_sysout_line, httpc, &st);
         if (rc < 0) goto quit;
+
+        why = do_print_sysout_why(&st);
+        if (why) {
+            rc = http_printf(httpc, "*** %-8.8s (DSID %u): %s ***\r\n",
+                             dd->ddname, dd->dsid, why);
+            if (rc < 0) goto quit;
+        }
 
         rc = http_printf(httpc, "- - - - - - - - - - - - - - - - - - - - "
                                 "- - - - - - - - - - - - - - - - - - - - "
@@ -683,16 +693,38 @@ quit:
 
 __asm__("\n&FUNC    SETC 'do_print_sysout_line'");
 static int
-do_print_sysout_line(const char *line, unsigned linelen)
+do_print_sysout_line(const char *line, unsigned linelen, void *arg)
 {
     int         rc      = 0;
-    CLIBGRT     *grt    = __grtget();
-    HTTPD       *httpd  = grt->grtapp1;
-    HTTPC       *httpc  = grt->grtapp2;
+    HTTPC       *httpc  = arg;              /* passed through by jesprint() */
+    HTTPD       *httpd  = httpc->httpd;     /* for the httpx macro          */
 
     rc = http_printf(httpc, "%-*.*s\r\n", linelen, linelen, line);
 
     return rc;
+}
+
+/* Why the block walk stopped, for the reasons the reader should hear about.
+   END and EMPTY are ordinary ends, and so is OPENEND: a data set that is
+   still being written ends on a block whose chain points at a track that is
+   allocated but not yet written, so it carries a foreign key - HTTPD showing
+   its own message log hits that every time.  STOPPED is our own callback
+   giving up (the client went away), which the caller sees as rc.           */
+__asm__("\n&FUNC    SETC 'do_print_sysout_why'");
+static const char *
+do_print_sysout_why(const JESPRST *st)
+{
+    switch (st->reason) {
+    case JESPR_IOERR:   return "spool read failed";
+    case JESPR_FOREIGN: return "no longer on the spool";
+    case JESPR_DSID:    return "spool block belongs to another data set";
+    case JESPR_LOOP:    return "spool block chain loops, output truncated";
+    case JESPR_CAP:     return "spool block limit reached, output truncated";
+    case JESPR_NOBUF:   return "incomplete spanned record, output truncated";
+    case JESPR_NOMEM:   return "out of storage, output truncated";
+    }
+
+    return NULL;
 }
 
 typedef struct findjob {

--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -645,7 +645,7 @@ quit:
 }
 
 static int do_print_sysout_line(const char *line, unsigned linelen, void *arg);
-static const char *do_print_sysout_why(const JESPRST *st);
+static const char *do_print_sysout_why(const JESPRST *st, unsigned records);
 __asm__("\n&FUNC    SETC 'do_print_sysout'");
 static int
 do_print_sysout(HTTPD *httpd, HTTPC *httpc, JES *jes, JESJOB *job, unsigned **dsid)
@@ -673,7 +673,7 @@ do_print_sysout(HTTPD *httpd, HTTPC *httpc, JES *jes, JESJOB *job, unsigned **ds
         rc = jesprint(jes, job, dd->dsid, do_print_sysout_line, httpc, &st);
         if (rc < 0) goto quit;
 
-        why = do_print_sysout_why(&st);
+        why = do_print_sysout_why(&st, dd->records);
         if (why) {
             rc = http_printf(httpc, "*** %-8.8s (DSID %u): %s ***\r\n",
                              dd->ddname, dd->dsid, why);
@@ -709,14 +709,22 @@ do_print_sysout_line(const char *line, unsigned linelen, void *arg)
    still being written ends on a block whose chain points at a track that is
    allocated but not yet written, so it carries a foreign key - HTTPD showing
    its own message log hits that every time.  STOPPED is our own callback
-   giving up (the client went away), which the caller sees as rc.           */
+   giving up (the client went away), which the caller sees as rc.
+
+   records is the count the PDDB advertises, and FOREIGN needs it: "purged"
+   means the checkpoint promises records the spool no longer holds.  A data
+   set nobody ever wrote to promises nothing, yet its allocated-but-unwritten
+   track carries a foreign key just the same - and with no accepted block
+   before it, libc370 cannot call that OPENEND.  Measured on the target:
+   SYSLOG DSID 101 (records=32) is a real loss, while DSID 103 and HTTPD's
+   own HTTPDERR/HTTPDOUT (records=0) are merely empty.                      */
 __asm__("\n&FUNC    SETC 'do_print_sysout_why'");
 static const char *
-do_print_sysout_why(const JESPRST *st)
+do_print_sysout_why(const JESPRST *st, unsigned records)
 {
     switch (st->reason) {
     case JESPR_IOERR:   return "spool read failed";
-    case JESPR_FOREIGN: return "no longer on the spool";
+    case JESPR_FOREIGN: return records ? "no longer on the spool" : NULL;
     case JESPR_DSID:    return "spool block belongs to another data set";
     case JESPR_LOOP:    return "spool block chain loops, output truncated";
     case JESPR_CAP:     return "spool block limit reached, output truncated";

--- a/src/jespr.c
+++ b/src/jespr.c
@@ -5,7 +5,7 @@
 #define httpx   (httpd->httpx)
 
 static int print_sysout(HTTPD *httpd, JES *jes, JESJOB *job, unsigned **dsid);
-static int prtline(const char *line, unsigned linelen);
+static int prtline(const char *line, unsigned linelen, void *arg);
 
 int main(int argc, char **argv)
 {
@@ -163,7 +163,7 @@ print_sysout(HTTPD *httpd, JES *jes, JESJOB *job, unsigned **dsid)
 
         if ((dd->flag & FLAG_SYSIN) && !dsid) continue;   /* don't show SYSIN data        */
 
-        rc = jesprint(jes, job, dd->dsid, prtline);
+        rc = jesprint(jes, job, dd->dsid, prtline, NULL, NULL);
         printf("- - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - "
                "- - - - - - - - - - - - - - - - - - - - "
@@ -174,7 +174,7 @@ print_sysout(HTTPD *httpd, JES *jes, JESJOB *job, unsigned **dsid)
 }
 
 __asm__("\n&FUNC    SETC 'prtline'");
-static int prtline(const char *line, unsigned linelen)
+static int prtline(const char *line, unsigned linelen, void *arg)
 {
     printf("%-*.*s\n", linelen, linelen, line);
     return 0;

--- a/src/jesst.c
+++ b/src/jesst.c
@@ -5,7 +5,7 @@
 #define httpx   (httpd->httpx)
 
 static int print_dd(HTTPD *httpd, JESJOB *j, const char *in);
-static int prtline(const char *line, unsigned linelen);
+static int prtline(const char *line, unsigned linelen, void *arg);
 
 int main(int argc, char **argv)
 {
@@ -164,11 +164,11 @@ int main(int argc, char **argv)
 
         if (!j) continue;
         if (strcmp(j->jobname, "BSPPILOT")==0) {
-            rc = jesprint(jes, j, 1, prtline);
-            rc = jesprint(jes, j, 2, prtline);
-            rc = jesprint(jes, j, 3, prtline);
-            rc = jesprint(jes, j, 4, prtline);
-            rc = jesprint(jes, j, 5, prtline);
+            rc = jesprint(jes, j, 1, prtline, NULL, NULL);
+            rc = jesprint(jes, j, 2, prtline, NULL, NULL);
+            rc = jesprint(jes, j, 3, prtline, NULL, NULL);
+            rc = jesprint(jes, j, 4, prtline, NULL, NULL);
+            rc = jesprint(jes, j, 5, prtline, NULL, NULL);
             break;
         }
     }
@@ -180,7 +180,7 @@ quit:
     return 0;
 }
 #if 0
-static int prtline(const char *line, unsigned linelen)
+static int prtline(const char *line, unsigned linelen, void *arg)
 {
     printf("%-*.*s\n", linelen, linelen, line);
     return 0;


### PR DESCRIPTION
Fixes #129.

libc370 (mvslovers/libc370#31) gives `jesprint()` a callback context parameter
and an optional `JESPRST` report. The change is source **and** binary breaking:
the build here fails today with `too few arguments to function 'jesprint'` in
`httpjes2.c`, and the statically autocalled library has to be relinked either
way.

## Changes

**`src/jespr.c`** — `prtline()` takes the extra `void *arg`; the call passes
`NULL` for both `arg` and `st`. The callback prints with `printf()` and carries
no context.

**`src/jesst.c`** — the same, for the five calls and the `prtline()` body that
sit inside `#if 0`. They do not break the build, but leaving stale calls there
means the next person to enable the block hits a signature error.

**`src/httpjes2.c`** — the `HTTPC *` now travels in `arg`, which retires the
`__grtget()` lookup in `do_print_sysout_line()`; the server block comes off
`httpc->httpd` for the `httpx` macro.

`do_print_sysout()` also reads the report and appends one line when the walk
stopped on something the reader should hear about:

```
*** JESMSGLG (DSID 2): no longer on the spool ***
```

covering `JESPR_IOERR`, `_FOREIGN`, `_DSID`, `_LOOP`, `_CAP`, `_NOBUF` and
`_NOMEM`. `END` and `EMPTY` stay silent, and so does `OPENEND` — a foreign
block *after* at least one accepted block is the normal end of a data set that
is still being written, which HTTPD showing its own message log hits every
time. Only `JESPR_FOREIGN` (first block foreign, nothing read) means gone.

## Verification

`make all` (6 modules + library), `make test` (10 test modules) and
`make test-host` (51 assertions, 0 fail) are clean against the updated libc370
sysroot. CI clones libc370 from `main`, which carries f4e6bd8, so the PR build
resolves the new signature.

Not verified on the target: the spool paths need a deploy. Worth checking after
install that browsing a running job's output (HTTPD's own STC is the easiest
case) prints its lines and ends **without** a note — that is the `OPENEND` path
that must not read as an error.

`mvsmf` and `ftpd` route their callback context through the GRT the same way
and need the same migration; tracked separately in mvslovers/libc370#18.
