### PR TITLE
feat: add 410 Gone to httpresp()

### DIFF
--- a/src/httpresp.c
+++ b/src/httpresp.c
@@ -35,6 +35,7 @@ httpresp(HTTPC *httpc, int resp)
     case 404: p = "404 Not Found";              break;
     case 405: p = "405 Method Not Allowed";     break;
     case 409: p = "409 Conflict";               break;
+    case 410: p = "410 Gone";                   break;
     case 413: p = "413 Payload Too Large";      break;
     case 414: p = "414 URI Too Long";           break;
     case 500: p = "500 Internal Server Error";  break;


### PR DESCRIPTION
Fixes #132.

`httpresp()` did not know **410**; it fell through to `default:` and put
`500 Internal Server Error` on the wire. A CGI that passes 410 to `http_resp()` could not
tell a client that a resource existed and is gone.

Same gap as #28, which added 405/409/414/507.

```diff
     case 409: p = "409 Conflict";               break;
+    case 410: p = "410 Gone";                   break;
     case 413: p = "413 Payload Too Large";      break;
```

## Consumer

mvslovers/mvsmf#187, the spool records endpoint. libc370's new `jesprint()` statistics
(mvslovers/libc370#31) report `JESPR_FOREIGN` when the **first** spool block already belongs
to another job: JES2 printed and purged the data set and reallocated its tracks, while the
checkpointed PDDB still advertises it with a non-zero record count. The job and the DD do
exist, so 404 is wrong; nothing was read, so an empty 200 is wrong too.

## Verified

`make` — all 6 modules link clean. The status line is produced in the server address space,
so the HTTPD load module must be redeployed before a CGI sees `410 Gone` on the wire.

https://claude.ai/code/session_019ibLZobVRy47xfNgEKxpS2