### PR TITLE
fix(httpjes2): take the callback stop from JESPRST, not jesprint()'s rc

### DIFF
--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -671,6 +671,16 @@ do_print_sysout(HTTPD *httpd, HTTPC *httpc, JES *jes, JESJOB *job, unsigned **ds
         if ((dd->flag & FLAG_SYSIN) && !dsid) continue;   /* don't show SYSIN data        */
 
         rc = jesprint(jes, job, dd->dsid, do_print_sysout_line, httpc, &st);
+
+        /* Since libc370 #26 rc is a status (0/404/503) and no longer carries
+           the print callback's rc: our own callback giving up - the client
+           went away - arrives as JESPR_STOPPED with its rc in st.prtrc.
+           Reading st also works against a pre-#26 libc370, which additionally
+           returned that rc here.                                            */
+        if (st.reason == JESPR_STOPPED) {
+            rc = st.prtrc;
+            goto quit;
+        }
         if (rc < 0) goto quit;
 
         why = do_print_sysout_why(&st, dd->records);
@@ -709,7 +719,8 @@ do_print_sysout_line(const char *line, unsigned linelen, void *arg)
    still being written ends on a block whose chain points at a track that is
    allocated but not yet written, so it carries a foreign key - HTTPD showing
    its own message log hits that every time.  STOPPED is our own callback
-   giving up (the client went away), which the caller sees as rc.
+   giving up (the client went away); since libc370 #26 the caller sees that in
+   st->reason/st->prtrc, not in jesprint()'s rc.
 
    records is the count the PDDB advertises, and FOREIGN needs it: "purged"
    means the checkpoint promises records the spool no longer holds.  A data


### PR DESCRIPTION
Adapts the JES2 SYSOUT browser to **libc370 #26**, which makes `jesprint()`'s return value a status and nothing else (`0` / `404` / `503`). It no longer carries the print callback's rc.

`do_print_sysout()` had exactly one thing riding on that rc:

```c
rc = jesprint(jes, job, dd->dsid, do_print_sysout_line, httpc, &st);
if (rc < 0) goto quit;          /* client went away */
```

`do_print_sysout_line()` returns `http_printf()`'s rc, so a client that disconnects mid-transfer showed up as a negative `rc`. After #26 that test never fires and the server reads the rest of the spool data set into a dead socket. Nothing warns — the signature is unchanged, so it compiles and just stops noticing.

The stop is now taken from the `JESPRST` out-parameter: `JESPR_STOPPED` with the callback's rc in `st.prtrc`. The `rc < 0` test stays as a cheap backstop. The stale comment on `do_print_sysout_why()` ("which the caller sees as rc") is corrected.

`jesst.c`'s `jesprint()` calls are inside `#if 0`, and `jespr.c` assigns the rc but returns 0 regardless — neither needs a change.

### Merge order

**This can merge first.** `JESPRST` has carried `reason`/`prtrc` since libc370 PR #31, so reading `st` is correct against today's libc370 *and* against #26.

Upstream: mvslovers/libc370#26 (PR mvslovers/libc370#40).

### Verified

`make` green against both the pre-#26 libc370 in the sysroot and the #26 build; all 6 modules link. The new libc370 splits the record walk into `@@JESPRB` (its #25) — confirmed that ld370 autocalls it into HTTPJES2.