### PR TITLE
Accept RACHECK rc=4 (resource not protected) as allowed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,12 @@ serves a file or dispatches a CGI:
    RACF/RAKF check (RACHECK/FRACHECK) under the client's ACEE. On denial it
    answers **403**.
 
+> **A `RES=` resource with no profile defined permits the access.** That is
+> standard SAF behaviour — an undefined resource is "not protected", not
+> "denied" — so a typo in the class or resource name silently disables stage 2
+> for that route rather than locking it. `DEBUG 1` traces every such check, so
+> verify a new `RES=` route against the debug log before relying on it.
+
 | Option | Values | Description |
 |--------|--------|-------------|
 | `AUTH=` | `NONE` \| `FORM` \| `BASIC` | Challenge for stage 1. `NONE` = public (no authentication). `FORM` = redirect to the HTML login form. `BASIC` = `401 WWW-Authenticate: Basic`. **Omitted** = inherit the global `LOGIN` default (backward compatible). |

--- a/include/httpcgi.h
+++ b/include/httpcgi.h
@@ -547,6 +547,22 @@ struct httpx {
 #define http_get_token(httpc,out,outlen) \
     ((httpx->http_get_token)((httpc),(out),(outlen)))
 
+/* RACF resource check under the client's ACEE.  classname/resource name the
+** profile (e.g. "FACILITY", "MVSMF.ACCESS"), attr is one of
+** RACF_ATTR_READ/UPDATE/CONTROL/ALTER (0 -> READ).
+**
+**    0  access permitted
+**   8+  access refused (the SAF rc)
+**   -1  the request is not authenticated (no credential / no ACEE)
+**
+** SAF answers rc 4 ("no profile covers the resource") for an unprotected
+** resource, which is an *allowed* answer; the server normalizes it to 0 so this
+** contract holds for modules built before that distinction became visible.
+**
+** So `if (http_check_auth(...) == 0)` is correct and stays correct.  Never test
+** `rc <= 4` -- it reads the -1 as allowed and lets unauthenticated callers past
+** the check.
+*/
 #define http_check_auth(httpc,classname,resource,attr) \
     ((httpx->http_check_auth)((httpc),(classname),(resource),(attr)))
 

--- a/include/httpd.h
+++ b/include/httpd.h
@@ -513,6 +513,9 @@ extern void *http_cgictx_get(HTTPD *, const char *, unsigned)              asm("
 extern UCHAR *http_get_userid(HTTPC *, UCHAR *out, unsigned outlen)         asm("HTTPGUID");
 extern ACEE *http_get_acee(HTTPC *)                                        asm("HTTPGACE");
 extern int http_get_token(HTTPC *, UCHAR *out, unsigned outlen)            asm("HTTPGTOK");
+/* 0 == permitted (SAF rc 4, "resource not protected", is normalized to 0),
+   8 and up == refused, -1 == the request is not authenticated.  Never test
+   rc <= 4: that reads the -1 as allowed.  See src/httpxauth.c. */
 extern int http_check_auth(HTTPC *, const char *classname,
                            const char *resource, int attr)                asm("HTTPCKAU");
 extern int http_logout(HTTPC *)                                           asm("HTTPLOUT");

--- a/include/httpracf.h
+++ b/include/httpracf.h
@@ -1,0 +1,27 @@
+/* HTTPRACF.H
+** Decide whether a RACHECK (racf_auth()) return code allows the access.
+**
+** Free of httpd.h so the pure decision logic unit-tests on the host as well as
+** on MVS (see test/tstracf.c).  The name is 8 characters so it needs no asm()
+** CSECT alias -- same reason as httpbody().
+*/
+#ifndef HTTPRACF_H
+#define HTTPRACF_H
+
+/* The SAF return codes racf_auth() can answer with.  0 and 4 are both
+** "allowed" -- 0 says a profile permits the access, 4 says no profile covers
+** the resource at all.  8 and up are refusals. */
+#define HTTP_RACF_PERMITTED     0   /* a profile permits the access         */
+#define HTTP_RACF_NOTPROT       4   /* no profile covers the resource       */
+
+/* Does this racf_auth() rc allow the access?  Returns 1 for the two SAF
+** "allowed" codes, 0 for everything else.
+**
+** Everything else deliberately includes negative values: http_check_auth()
+** answers -1 for an unauthenticated request, and the tempting shorthand for
+** "0 or 4" -- rc <= 4 -- would let that through as allowed.  Testing the two
+** codes explicitly is the whole point of this function existing.
+*/
+int httpracf(int rc);
+
+#endif /* HTTPRACF_H */

--- a/project.toml
+++ b/project.toml
@@ -107,6 +107,13 @@ sources = ["test/tstbody.c", "src/httpbody.c"]
 name = "TSTEXPIRE"
 sources = ["test/tstexpire.c", "credentials/src/credexp.c"]
 
+# httpracf() SAF authorization decision table (issue #135): rc 0 and 4 both
+# allow, -1 must not.  Free of httpd.h -> DUAL (host + MVS); helper source
+# listed for the host link.
+[[test]]
+name = "TSTRACF"
+sources = ["test/tstracf.c", "src/httpracf.c"]
+
 # credid_enc()/credid_dec() round-trip + flag survival across a repeat read of a
 # stored CRED (issue #109: http_get_userid() garbage on a cache-hit read).
 # blowfish_encrypt/decrypt are crent370 (MVS) -> MVS-only test (test-mvs); the

--- a/src/httppc.c
+++ b/src/httppc.c
@@ -374,7 +374,13 @@ auth_gate(HTTPC *httpc, HTTPCGI *route)
 	}
 
 	/* Stage 2: authorize the resource under the client's ACEE.  Skipped for
-	   AUTH=NONE (a public route has no identity to check -> NONE wins). */
+	   AUTH=NONE (a public route has no identity to check -> NONE wins).
+
+	   != 0 is the whole denial test: http_check_auth() already normalizes the
+	   second SAF "allowed" code (rc 4, resource not protected) to 0, and it
+	   answers -1 for an unauthenticated request.  Do NOT relax this to <= 4 --
+	   that reads -1 as allowed.  See httpxauth.c for why the normalization
+	   lives there and not here. */
 	if (route && route->resclass && route->resname && authed &&
 	    mode != HTTP_AUTH_NONE) {
 		if (http_check_auth(httpc, route->resclass, route->resname,

--- a/src/httpracf.c
+++ b/src/httpracf.c
@@ -1,0 +1,12 @@
+/* HTTPRACF.C
+** Decide whether a RACHECK (racf_auth()) return code allows the access.
+**
+** Kept free of httpd.h so the SAF decision table unit-tests dual (host + MVS).
+*/
+#include "httpracf.h"
+
+int
+httpracf(int rc)
+{
+    return (rc == HTTP_RACF_PERMITTED || rc == HTTP_RACF_NOTPROT);
+}

--- a/src/httpxauth.c
+++ b/src/httpxauth.c
@@ -14,6 +14,7 @@
 */
 #define HTTP_PRIVATE
 #include "httpd.h"
+#include "httpracf.h"
 
 /* http_get_userid() - copy the client's userid into the caller's buffer as a
 ** NUL-terminated string.  Returns out on success, or NULL if there is no
@@ -57,7 +58,13 @@ http_get_userid(HTTPC *httpc, UCHAR *out, unsigned outlen)
 
 /* http_get_acee() - the client's RACF ACEE, or NULL when the request is not
 ** authenticated.  A CGI may hand this to racf_set_acee()/racf_auth() to run
-** work under the client's identity. */
+** work under the client's identity.
+**
+** A CGI that calls racf_auth() itself sees the RAW SAF rc, which is NOT the
+** contract http_check_auth() publishes below: an unprotected resource answers
+** 4, not 0, and testing rc == 0 / != 0 turns that allowed access into a denial.
+** Use http_check_auth() unless the raw distinction is actually wanted, and if it
+** is, accept both 0 and 4 (see httpracf()). */
 __asm__("\n&FUNC SETC 'HTTPGACE'");
 #undef http_get_acee
 ACEE *
@@ -84,15 +91,65 @@ http_get_token(HTTPC *httpc, UCHAR *out, unsigned outlen)
 }
 
 /* http_check_auth() - RACF resource check under the client's ACEE.  attr is
-** one of RACF_ATTR_READ/UPDATE/CONTROL/ALTER (0 -> READ).  Returns the
-** racf_auth() rc (0 == access permitted), or -1 when unauthenticated. */
+** one of RACF_ATTR_READ/UPDATE/CONTROL/ALTER (0 -> READ).  Returns 0 when the
+** access is permitted, the racf_auth() rc (8 and up) on a refusal, or -1 when
+** the request is unauthenticated.
+**
+** SAF has two "allowed" answers: rc 0 (a profile permits the access) and rc 4
+** (no profile covers the resource).  We normalize 4 to 0 here, so the contract
+** this vector entry has published since it was added -- 0 == permitted -- keeps
+** holding.  Three reasons that is the right call rather than the information
+** hiding it looks like:
+**
+**   - The rc reaches CGI modules through the HTTPX vector, and modules are
+**     LINKed at runtime.  Widening the contract to "0 or 4" would leave every
+**     not-yet-rebuilt module denying access to unprotected resources, with no
+**     build-time signal that it has to move.
+**   - This function already invents -1 for "unauthenticated", so it was never a
+**     SAF pass-through -- the published contract is ours, not SAF's.  Worse, the
+**     natural widened idiom `rc <= 4` would read -1 as allowed and let
+**     unauthenticated requests straight through the gate.
+**   - rc 4 never means denied (0 permitted, 4 not protected, 8+ refused), so
+**     collapsing it into 0 cannot soften a denial.
+**
+** Until libc370 #63 the distinction was invisible: racf_auth() set RACHECK flag
+** byte 0x10 believing it meant LOG=NONE, when that bit is DSTYPE=V, and with
+** that flag RAKF answered 0 where it should answer 4.  With the flag corrected
+** the 4 becomes visible to every caller -- including httpd's own RES= route gate
+** in auth_gate() (httppc.c), which tests != 0 and would otherwise 403 every
+** request to a route whose resource has no profile.
+**
+** A resource with no profile passing the gate is SAF-correct, but it is also
+** exactly the shape of a misconfigured RES= route, so trace it when DEBUG is on
+** -- it is the only place the distinction is still visible.
+**
+** One caveat on that trace: dbgf() resolves HTTPD through __grtget()->grtapp1
+** and writes httpd->dbg, a FILE* owned by httpd's C runtime, so reached from a
+** CGI it touches another runtime's stdio state.  That is the same thing the
+** vector's own http_dbgf entry does, so it is the sanctioned pattern rather than
+** a new one -- but it has not been exercised from a CGI, and today it cannot be:
+** no CGI calls http_check_auth(), and with DEBUG 0 (the default) dbgf() returns
+** after two loads.  A first CGI consumer plus DEBUG 1 is the combination to
+** verify before trusting it. */
 __asm__("\n&FUNC SETC 'HTTPCKAU'");
 #undef http_check_auth
 int
 http_check_auth(HTTPC *httpc, const char *classname, const char *resource, int attr)
 {
+    int rc;
+
     if (!httpc || !httpc->cred || !httpc->cred->acee) return -1;
-    return racf_auth(httpc->cred->acee, classname, resource, attr);
+
+    rc = racf_auth(httpc->cred->acee, classname, resource, attr);
+
+    if (rc == HTTP_RACF_NOTPROT) {
+        http_dbgf("http_check_auth(%s:%s) rc=4: resource not protected,"
+                  " access allowed\n",
+                  classname ? classname : "(null)",
+                  resource  ? resource  : "(null)");
+    }
+
+    return httpracf(rc) ? HTTP_RACF_PERMITTED : rc;
 }
 
 /* http_logout() - end the client's session: drop the CRED (and its ACEE) from

--- a/test/tstracf.c
+++ b/test/tstracf.c
@@ -1,0 +1,56 @@
+/* TSTRACF.C
+** Tests for httpracf() -- the SAF authorization decision table (src/httpracf.c)
+** behind http_check_auth()'s "0 == permitted" contract and the RES= route gate
+** in auth_gate() (src/httppc.c).
+**
+** The case that matters is rc 4.  racf_auth() used to answer 0 for a resource
+** with no profile because libc370 set RACHECK flag 0x10 believing it meant
+** LOG=NONE (it is DSTYPE=V; libc370 #63).  With the flag corrected the same
+** check answers 4, and any test of "rc == 0" / "rc != 0" flips an allowed
+** access into a denial -- for a route carrying RES=FACILITY:MVSMF.ACCESS on a
+** system without that profile, a 403 on every request.
+**
+** The -1 cases guard the other half: http_check_auth() answers -1 for an
+** unauthenticated request, so the shorthand "rc <= 4" for "0 or 4" would let an
+** unauthenticated caller through.  That is why this is a function and not an
+** inline comparison.
+**
+** httpracf() is free of httpd.h, so this is a DUAL test: it runs natively via
+** `make test-host` and on MVS via `make test-mvs`.
+*/
+#include <stdio.h>
+#include "httpracf.h"
+#include <mbtcheck.h>
+
+int main(void)
+{
+    printf("=== HTTPD httpracf (SAF authorization rc) tests ===\n");
+
+    /* the two SAF "allowed" answers */
+    CHECK(httpracf(HTTP_RACF_PERMITTED) == 1,
+          "rc 0 (a profile permits the access) -> allowed");
+    CHECK(httpracf(HTTP_RACF_NOTPROT) == 1,
+          "rc 4 (resource not protected) -> allowed (libc370 #63)");
+
+    /* the constants must keep naming the SAF codes they claim to name */
+    CHECK(HTTP_RACF_PERMITTED == 0, "HTTP_RACF_PERMITTED is SAF rc 0");
+    CHECK(HTTP_RACF_NOTPROT == 4, "HTTP_RACF_NOTPROT is SAF rc 4");
+
+    /* refusals: 8 is "access denied", and anything above stays a refusal */
+    CHECK(httpracf(8) == 0, "rc 8 (access denied) -> denied");
+    CHECK(httpracf(12) == 0, "rc 12 -> denied");
+    CHECK(httpracf(16) == 0, "rc 16 -> denied");
+
+    /* not an SAF rc: http_check_auth()'s unauthenticated sentinel.  A `rc <= 4`
+       test would call these allowed -- they must not be. */
+    CHECK(httpracf(-1) == 0,
+          "rc -1 (unauthenticated) -> denied, NOT allowed by a <= 4 test");
+    CHECK(httpracf(-8) == 0, "any negative rc -> denied");
+
+    /* the odd values between the SAF multiples of 4 are not allowed answers */
+    CHECK(httpracf(1) == 0, "rc 1 -> denied (only 0 and 4 allow)");
+    CHECK(httpracf(3) == 0, "rc 3 -> denied");
+    CHECK(httpracf(5) == 0, "rc 5 -> denied");
+
+    return mbt_test_summary("TSTRACF");
+}


### PR DESCRIPTION
Fixes #135. Unblocks mvslovers/libc370#63 — httpd was the last consumer holding it up (ftpd landed its side in `fc26874`).

## The correction to the issue

The issue states httpd "makes no decision on the value — it hands it to CGIs through the HTTPX vector". That is not the case: `auth_gate()` in `src/httppc.c` tests `!= 0` for its `RES=` route gate, added in `9e7014e` (per-route auth policy) a month before the issue was written.

With the documented example from `docs/configuration.md`:

```
MOD=MVSMF /zosmf/*  AUTH=BASIC RES=FACILITY:MVSMF.ACCESS
```

on a system where `MVSMF.ACCESS` has no profile, RACHECK answers 4 after libc370#63 and **every `/zosmf/*` request gets a 403**. So this is an outage in the httpd core, not only a CGI contract question.

## What was picked, and why

Option 2 from the issue (normalize 4 → 0 in `http_check_auth()`), but the deciding argument is not the one the issue gives.

The issue argues for option 2 because runtime-loaded modules make a contract change expensive. That is true in principle but currently hypothetical — grepping mvsmf, httplua, httprexx and every in-tree CGI (`httpdsrv.c`, `httpjes2.c`, `httpdsl.c`) for `http_check_auth` / `HTTPCKAU` finds **zero** consumers. httpd's own `auth_gate()` is the only caller today.

The load-bearing argument is httpd-specific: `http_check_auth()` returns **-1** for unauthenticated. It was never a SAF pass-through — the published contract is httpd's, not SAF's. And the widened idiom libc370#63 itself suggests, `rc <= 4`, would read that **-1 as allowed and let unauthenticated requests past the gate**. Option 1 would have to renumber -1 as well, breaking existing `== -1` checks. Option 2 sidesteps it, and because the normalization sits in `httpxauth.c`, `httppc.c` is correct unchanged.

rc 4 never means denied (0 permitted, 4 not protected, 8+ refused), so collapsing it into 0 cannot soften a denial.

This also explains why ftpd's opposite choice (`ftpd_racf_allowed()`, `rc == 0 || rc == 4` at the call sites) is not an inconsistency: ftpd calls `racf_auth()` directly and has no sentinel value in the range.

## Changes

- `src/httpracf.c` + `include/httpracf.h` — `httpracf(rc)`, the SAF decision table. Free of `httpd.h` (like `httpbody()`) so it unit-tests dual host/MVS; 8-char name, no asm alias needed.
- `src/httpxauth.c` — `http_check_auth()` normalizes 4 → 0, plus the rationale and a `DEBUG` trace for the not-protected case (the only place the distinction is still visible).
- `src/httppc.c` — comment pinning why `!= 0` is the whole test and must not be relaxed to `<= 4`.
- `include/httpd.h`, `include/httpcgi.h` — the return contract documented at both declaration sites. `httpcgi.h` is the one CGI authors read.
- `test/tstracf.c` + `project.toml` — `[[test]] TSTRACF`, 12 assertions.
- `docs/configuration.md` — a `RES=` resource with no profile permits access; a typo silently disables stage 2 rather than locking the route.

## Verification

- `make test-host` — 4 tests, 63 assertions, all pass (`TSTRACF` 12/12).
- Regression guard confirmed: reverting `httpracf()` to the pre-fix `rc == 0` makes `TSTRACF` fail on exactly the rc=4 assertion (11 pass / 1 fail), then passes again restored.
- `make` (cc370, `-Wall -Werror`) — clean, all 6 modules link.
- CI green (run 31155461716). Note the shared mbt workflow only runs `make deps` / `make` / `make test` / `make lib` — `make test` *builds* the test load modules, it never executes assertions. The 63 passing assertions above are from a local `make test-host`.

Not verified on the live MVS system: the end-to-end path still needs libc370#63 to land before rc 4 can actually be observed. This change is safe against both the old and the new library, which is why it goes first.

## To verify on MVS after libc370#63 lands

A route with `RES=` naming an undefined FACILITY profile must serve normally (not 403), and `DEBUG 1` should show the `rc=4: resource not protected` trace for it.

## Follow-up

The policy question is deliberately **not** settled here — whether an undefined `RES=` profile *should* mean "everyone passes" is a decision now that httpd can see the difference; today's permissiveness was an accident of the wrong flag bit. Filed separately so this PR stays behaviour-preserving.

## Noticed, not touched

`include/httpd.h:466` — `extern http_set_env(...)` is missing its `int` return type (implicit int, pre-existing). Out of scope here.