### PR TITLE
Remove the OR/BOR trigraphs and give http_set_env its return type

### DIFF
--- a/include/httpd.h
+++ b/include/httpd.h
@@ -59,13 +59,11 @@ typedef struct smf_httpd_session SMF_HTTPD_SESS;    /* SMF session  */
 typedef enum   cstate   CSTATE;     /* HTTP Client state            */
 typedef enum   rdw      RDW;        /* RDW option                   */
 
-#ifndef OR
-#define OR ??!??!                   /* logical OR trigraph          */
-#endif
-
-#ifndef BOR
-#define BOR ??!                     /* bitwise OR trigraph          */
-#endif
+/* The OR / BOR trigraph macros (??!??! and ??!) that used to live here are
+** gone: they existed because '|' is not typable on a 3270 keyboard, but the
+** sources are edited on the host now and '||' was already used on 64 lines
+** across 21 files.  Keeping them cost 257 -Wall warnings -- every translation
+** unit including this header -- for two remaining call sites. */
 
 extern UCHAR *ebc2asc;
 extern UCHAR *asc2ebc;
@@ -463,7 +461,7 @@ extern int http_send(HTTPC*,const UCHAR *,int)                          asm("HTT
 extern UCHAR *http_decode(UCHAR*)                                       asm("HTTPDECO");
 extern int http_del_env(HTTPC *, const UCHAR *name)                     asm("HTTPDENV");
 extern unsigned http_find_env(HTTPC *, const UCHAR *name)               asm("HTTPFENV");
-extern http_set_env(HTTPC *, const UCHAR *, const UCHAR *)              asm("HTTPSENV");
+extern int http_set_env(HTTPC *, const UCHAR *, const UCHAR *)          asm("HTTPSENV");
 extern HTTPV *http_new_env(const UCHAR *, const UCHAR *)                asm("HTTPNENV");
 extern int http_set_http_env(HTTPC *, const UCHAR *, const UCHAR *)     asm("HTTPSHEN");
 extern int http_set_query_env(HTTPC *, const UCHAR *, const UCHAR *)    asm("HTTPSQEN");

--- a/src/httpcmpn.c
+++ b/src/httpcmpn.c
@@ -21,7 +21,7 @@ httpcmpn(const UCHAR *s1, const UCHAR *s2, int n)
             c2 = tolower(c2);
         }
         
-        if ((--n == 0) ??!??! (c1 == '\0')) break;
+        if ((--n == 0) || (c1 == '\0')) break;
 
         ++s1;
         ++s2;

--- a/src/httpin.c
+++ b/src/httpin.c
@@ -253,7 +253,7 @@ http_in(HTTPC *httpc)
 
     httpc->len += rc;   /* update length of data in buffer */
 
-    if (strstr(httpc->buf, "\x0A\x0A") OR           /* ASCII LF LF */
+    if (strstr(httpc->buf, "\x0A\x0A") ||           /* ASCII LF LF */
         strstr(httpc->buf, "\x0D\x0A\x0D\x0A")) {   /* ASCII CRLF CRLF */
         /* we have a complete request in ASCII */
         httpc->state = CSTATE_PARSE;


### PR DESCRIPTION
First of four staged PRs for #138. This one is the cheap half: **347 of the 598 warnings, from two causes, in four edits** — and provably no code generation change.

## The trigraphs

`include/httpd.h` defined:

```c
#define OR  ??!??!      /* logical OR trigraph */
#define BOR ??!         /* bitwise OR trigraph */
```

They exist because `|` is not typable on a 3270 keyboard. That constraint is gone — these sources are cross-compiled from the host and edited in git, and the tree already contains `||` on **64 lines across 21 files** plus a bare `|` on 13 more. So the macros were not buying consistency; they were an island.

The cost was one warning per translation unit that included `httpd.h` — **257 of them** — for two remaining users:

- `src/httpin.c:256` used the `OR` macro
- `src/httpcmpn.c:24` had a raw `??!??!`
- `BOR` had no users at all

Both call sites become `||`. `httpcmpn.c` is `http_cmpn()`, which `httppc.c` and `httpprm.c` use for route and Parmlib parsing, so it is worth being explicit that `||` short-circuits identically here: the `--n` decrement is on the left of the operator and stays unconditional.

## The implicit int

```c
extern http_set_env(HTTPC *, const UCHAR *, const UCHAR *)  asm("HTTPSENV");
```

No return type, so implicit `int`, reported once per including TU: **85** in `src/`, **5** more in the test sources. The definition in `src/httpsenv.c` returns `int` and both HTTPX vector entries (`httpd.h:328`, `httpcgi.h:192`) already declare `int`, so there was never an ABI mismatch — just a declaration that never got its type.

## Verification

- **`cc370 -O1 -S` over all 114 translation units, before and after: byte-identical assembler.** That is the whole claim of this PR — it changes what the compiler reports, not what it emits.
- `make` clean, all 6 modules link.
- `make test-host`: 63 assertions pass.
- Warning count with `-Wall`: **598 → 251.**

## What is left, and where it goes

| count | warning | PR |
|---:|---|---|
| 93 | `suggest parentheses around assignment used as truth value` | 3 |
| 57 | `unused variable` | 3 |
| 40 | `label defined but not used` | 3 |
| 18 | `subscript has type 'char'` | 2 |
| 13 | `implicit declaration of function` | 2 |
| 8 | `declared static but never defined` | 3 |
| 6 | `might be used uninitialized` | 2 |
| 5 | `defined but not used` | 3 |
| 6 | format-string mismatches | 2 |
| 3 | misc (`missing braces`, `"/*" within comment`) | 2 |

PR 2 is the real defects — including the two-`%s`/one-argument `printf` at `httpdsl.c:43` that abends the very diagnostic meant to explain a misuse. PR 3 is the mechanical remainder, again `-S`-diff verified. PR 4 turns on `-Wall -Werror` in `project.toml`, which is what #138 is actually for.

No `-Wno-trigraphs` anywhere: deleting the macros is what makes the suppression unnecessary, and the root `CLAUDE.md` rule is "never suppress".