### PR TITLE
Fix the defects -Wall was hiding

### DIFF
--- a/credentials/src/credtest.c
+++ b/credentials/src/credtest.c
@@ -1,4 +1,5 @@
 #include "cred.h"
+#include <clibauth.h>	/* __autask() */
 #include <clibb64.h>	/* base64 encode/decode */
 #include <clibssib.h>	/* __jobid() */
 #include <clibtiot.h>	/* __jobname() */

--- a/src/cgistart.c
+++ b/src/cgistart.c
@@ -58,7 +58,7 @@ __start(char *p, char *pgmname, int tsojbid, void **pgmr1)
     char        *argv[MAXPARMS + 1];
     int         rc;
     int         parmLen;
-    int         progLen;
+    int         progLen = 0;
     char        parmbuf[310];
 
     /* we're going to process the callers parameter list first so we

--- a/src/dbgdump.c
+++ b/src/dbgdump.c
@@ -22,7 +22,7 @@ dump(FILE *fp, const char *pName, const void *pvArea, int iSize, int iChunk)
 
     fprintf(fp, "%*.*sDump of %08X \"%s\" (%d bytes)\n",
         indent, indent, "",
-        pArea, pName, iSize);
+        (unsigned int)pArea, pName, iSize);
 
     for (i=0, j=0; iSize > 0;i++ ) {
         if ( i==iChunk ) {

--- a/src/dbgtime.c
+++ b/src/dbgtime.c
@@ -38,7 +38,7 @@ dbgtime(const char *sep)
     if (!tm) goto quit;
 
     strftime(buf, sizeof(buf), "%Y%m%d.%H%M%S", tm);
-    fprintf(httpd->dbg, "%s.%06u%s", buf, tv.tv_usec, sep);
+    fprintf(httpd->dbg, "%s.%06lu%s", buf, tv.tv_usec, sep);
 
 quit:
     return rc;

--- a/src/httpcred.c
+++ b/src/httpcred.c
@@ -175,10 +175,10 @@ static int
 print_head(HTTPD *httpd, HTTPC *httpc)
 {
 	int		i;
-	int		rc;
+	int		rc = 0;		/* head[] could be empty -> rc read unwritten */
 
 	for(i=0; head[i]; i++) {
-		if (rc=http_printf(httpc, " %s\n", head[i])) goto quit;
+		if ((rc = http_printf(httpc, " %s\n", head[i]))) goto quit;
 	}
 
 quit:

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -9,6 +9,7 @@
 #include "httpd.h"
 #include "clibgrt.h"
 #include "clibsock.h"
+#include "clibauth.h"               /* __autask/__austep/__uatask/__uastep */
 
 static int socket_thread(void *arg1, void *arg2);
 static int worker_thread(void *udata, CTHDWORK *work);

--- a/src/httpdsl.c
+++ b/src/httpdsl.c
@@ -38,9 +38,9 @@ int main(int argc, char **argv)
 
     /* make sure we're running on the HTTPD server */
     if (!httpd) {
-        wtof("This program %s must be called by the HTTPD web server%s", "");
+        wtof("This program %s must be called by the HTTPD web server%s", argv[0], "");
         /* TSO callers might not see a WTO message, so we send a STDOUT message too */
-        printf("This program %s must be called by the HTTPD web server%s", "\n");
+        printf("This program %s must be called by the HTTPD web server%s", argv[0], "\n");
         return 12;
     }
 
@@ -178,7 +178,7 @@ do_print_binary(HTTPDS *ds)
     int         len;
     int         rc;
     char        dataset[256]= {0};
-    char        *buf;
+    char        *buf = NULL;
 
     if (!ds->dsn) {
         httpds_error(ds, "Missing ?dsn= query variable.\n");
@@ -252,7 +252,7 @@ do_print_text(HTTPDS *ds)
     int         len;
     int         rc;
     char        dataset[256]= {0};
-    char        *buf;
+    char        *buf = NULL;
 
     if (!ds->dsn) {
         httpds_error(ds, "Missing ?dsn= query variable.\n");

--- a/src/httpdsld.c
+++ b/src/httpdsld.c
@@ -6,8 +6,8 @@ DSLIST *httpds_dslist(const char *dsn)
 { 
     int         rc          = 0;
     char        volser[8]   = {0};
-    LOCWORK     workarea    = {0};
-    DSCB        dscbbuf     = {0};
+    LOCWORK     workarea    = {{0}};
+    DSCB        dscbbuf     = {{0}};
     DSCB        *dscb       = &dscbbuf;
     DSCB1       *dscb1      = &dscb->dscb1;
     DSLIST      *dslist     = NULL;

--- a/src/httpdslp.c
+++ b/src/httpdslp.c
@@ -81,7 +81,7 @@ do_pds_json(HTTPDS *ds, DSLIST *dslist, PDSLIST **pdslist)
     /* start of JSON data array */
     http_printf(httpc, "  \"data\": [\n");
 
-    count    = __arcou(&pdslist);
+    count    = array_count(&pdslist);
 
     if (strcmp(dslist->recfm, "U")!=0) {
         /* not a LOAD/LINK type PDS dataset */
@@ -184,7 +184,7 @@ do_pds_print(HTTPDS *ds, DSLIST *dslist, PDSLIST **pdslist)
     ISPFSTAT    *ispfstat   = (ISPFSTAT *)buf;
     unsigned    n, count;
 
-    count    = __arcou(&pdslist);
+    count    = array_count(&pdslist);
     if (!count) {
         http_resp(httpc, 404);  /* not found */
         http_printf(httpc, "Content-Type: text/plain\r\n");

--- a/src/httpfcgi.c
+++ b/src/httpfcgi.c
@@ -1,5 +1,10 @@
 #include "httpd.h"
 
+/* call http_cmp() directly (HTTPCMP), not through the httpx vector -- this is
+   the server's own code path and used to reach it as the bare CSECT name
+   httpcmp(), which had no prototype in scope. */
+#undef http_cmp
+
 HTTPCGI *httpfcgi(HTTPD *httpd, const char *path)
 {
     HTTPCGI     *cgi    = NULL;
@@ -23,7 +28,7 @@ HTTPCGI *httpfcgi(HTTPD *httpd, const char *path)
         }
         else {
             /* use caseless string compare */
-            if (httpcmp(path, p->path)==0) {
+            if (http_cmp(path, p->path)==0) {
                 cgi = p;
                 break;
             }

--- a/src/httpopen.c
+++ b/src/httpopen.c
@@ -7,7 +7,11 @@
 FILE *
 http_open(HTTPC *httpc, const UCHAR *path, const HTTPM *mime)
 {
-    UCHAR   *mode;
+    /* Initialized because mode is only assigned inside the if (mime) below and
+       -Wall cannot prove that branch always runs.  It does: http_mime() never
+       answers NULL -- an extension it does not know falls back to default_mime
+       {"txt","text/plain",0}, i.e. exactly this "r".  Defensive, not a fix. */
+    UCHAR   *mode = "r";
     int     len;
     UCHAR   buf[256];
 

--- a/src/httppcgi.c
+++ b/src/httppcgi.c
@@ -4,6 +4,11 @@
 */
 #include "httpd.h"
 
+/* call http_link() directly (HTTPLINK), not through the httpx vector -- this is
+   the server's own code path and used to reach it as the bare CSECT name
+   httplink(), which had no prototype in scope. */
+#undef http_link
+
 extern int
 httppcgi(HTTPC *httpc, HTTPCGI *cgi)
 {
@@ -12,7 +17,7 @@ httppcgi(HTTPC *httpc, HTTPCGI *cgi)
     http_enter("httppcgi()\n");
 
     /* link to external program */
-    rc = httplink(httpc, cgi->pgm);
+    rc = http_link(httpc, cgi->pgm);
     if (rc < 0) {
         /* some kind of ABEND occurred */
         unsigned abcode = (unsigned) (rc * -1);   /* make positive again */

--- a/src/httpprm.c
+++ b/src/httpprm.c
@@ -10,6 +10,13 @@
 #include "httpd.h"
 #include "httpxlat.h"
 
+/* libc370 ships sleep() (src/clib/sleep.c) and __tzset() (src/clib/@@tzset.c)
+** but declares neither in any header, so both were implicit declarations here.
+** Declared locally until libc370 exports them; the signatures are copied from
+** those definitions, so a later header will agree rather than conflict. */
+extern int sleep(unsigned seconds);
+extern int __tzset(int tzoffset);
+
 /* Forward declarations */
 static void set_defaults(HTTPD *httpd);
 static void parse_line(HTTPD *httpd, char *line);

--- a/src/httpstrt.c
+++ b/src/httpstrt.c
@@ -3,7 +3,10 @@
 #include "stdlib.h"
 #include "string.h"
 #include "stddef.h"
+#include "time.h"
 #include "clibcrt.h"
+#include "clibenv.h"                /* loadenv()                        */
+#include "clibwto.h"                /* wtof()                           */
 
 #define MAXPARMS 50 /* maximum number of arguments we can handle */
 
@@ -22,7 +25,7 @@ __start(char *p, char *pgmname, int tsojbid, void **pgmr1)
     char        *argv[MAXPARMS + 1];
     int         rc;
     int         parmLen;
-    int         progLen;
+    int         progLen = 0;
     char        parmbuf[310];
 
     /* need to know if this is a TSO environment straight away

--- a/src/httpx.c
+++ b/src/httpx.c
@@ -58,7 +58,7 @@ static HTTPX vect = {
     http_resp_not_found,        /* C8 http_resp_not_found()         */
     http_open,                  /* CC http_open()                   */
     http_send_binary,           /* D0 http_send_binary()            */
-    0,  /* httpread,            /* D4 http_read()                   */
+    0,                          /* D4 http_read() -- not exported   */
     http_send_file,             /* D8 http_send_file()              */
     http_send_text,             /* DC http_send_text()              */
     http_is_busy,               /* E0 http_is_busy()                */

--- a/src/jesst.c
+++ b/src/jesst.c
@@ -126,14 +126,14 @@ int main(int argc, char **argv)
             printf("      \"end_display\": \"...\",\n" );
         }
 #else
-        printf("      \"start_stamp\": \"%llu\",\n", j->start_time64 );
+        printf("      \"start_stamp\": \"%llu\",\n", j->start_time64.u64 );
         if (__64_cmp_u32(&j->start_time64, 0) != __64_EQUAL) {
             printf("      \"start_display\": \"%-24.24s\",\n", ctime64(&j->start_time64) );
         }
         else {
             printf("      \"start_display\": \"...\",\n");
         }
-        printf("      \"end_stamp\": \"%llu\",\n", j->end_time64);
+        printf("      \"end_stamp\": \"%llu\",\n", j->end_time64.u64);
         if (__64_cmp_u32(&j->end_time64, 0) != __64_EQUAL) {
             printf("      \"end_display\": \"%-24.24s\",\n", ctime64(&j->end_time64) );
         }
@@ -244,6 +244,6 @@ print_dd(HTTPD *httpd, JESJOB *j, const char *in)
         printf("%s  }%s\n", in, (n+1) < count ? "," : "");
     }
 
-    printf("%s]\n");
+    printf("%s]\n", in);
     return 0;
 }


### PR DESCRIPTION
Second of four staged PRs for #138. **Stacked on #139** — base is `issue-138-enforce-wall-werror`, so review that one first. 251 → 220 warnings.

This is the bucket that needed individual reasoning per site, not a mechanical edit.

## Real defects

**`httpdsl.c:41,43` — two `%s`, one argument**, in both the `wtof()` and the `printf()`:

```c
wtof("This program %s must be called by the HTTPD web server%s", "");
```

The second conversion reads past the end of the varargs area and dereferences it as a `char *`. All four sibling CGIs (`httpdm`, `httpdmtt`, `httpdsrv`, `httpjes2`) pass `argv[0]` here; `httpdsl` was the one that lost it, so it is restored rather than the `%s` deleted.

Narrower than it looks, though: reaching this guard needs `HTTPDOUT`/`HTTPDERR`/`HTTPDIN` allocated *and* `grtapp1` NULL. A bare TSO `CALL` never gets there — `cgistart.c:110-111` exits in `__start` over the missing DD first, silently. That is #141, and is not fixed here.

**`jesst.c:247` — `printf("%s]\n")` with no argument at all.** Same shape. Every other `printf` in that function passes the indent string `in`, which is what belongs there; deleting the `%s` instead would have silently changed the JSON indentation.

**`dbgdump.c:25`** printed a pointer through `%08X`, **`dbgtime.c:41`** a `long` through `%06u`.

`jesst.c:129,136` passed `time64_t` (a `__64` union) to `%llu`. Checked the generated assembler before changing it — `MVC 92(8,13),56(4)` moves the 8 bytes inline, so the union was already passed by value exactly as `%llu` expects. That one was a warning and not a bug; it now names `.u64` explicitly.

## Implicit declarations (13)

Five needed a header that was simply not included: `clibauth.h` in `httpd.c` (covers `__autask`/`__austep`/`__uatask`/`__uastep`) and `credtest.c`, plus `time.h` / `clibenv.h` / `clibwto.h` in `httpstrt.c`.

Three were calls to **CSECT names that have no C prototype**:

| call | is really | fix |
|---|---|---|
| `httpfcgi.c` → `httpcmp()` | `HTTPCMP` | `http_cmp()` + `#undef` |
| `httppcgi.c` → `httplink()` | `HTTPLINK` | `http_link()` + `#undef` |
| `httpdslp.c` → `__arcou()` | `@@ARCOU` | `array_count()` |

The `#undef` matters: without `HTTP_PRIVATE`, `http_cmp`/`http_link` are the httpx *macros*, so writing them plainly would have turned a direct call into a vector call. `#undef` restores the direct extern — the same pattern `httpxauth.c` and `httpgufs.c` already use. `__arcou` was never an API name; the declared entry for `@@ARCOU` is `array_count()`.

`sleep()` and `__tzset()` are the exception: **libc370 ships both** (`src/clib/sleep.c`, `src/clib/@@tzset.c`) **and declares neither in any header.** `httpprm.c` declares them locally with the signatures copied from those definitions, so a later libc370 header will agree rather than conflict. Worth an issue against libc370.

## Silenced, not fixed (false positives)

**`httpopen.c`'s `mode`** is only assigned inside `if (mime)`, which `-Wall` cannot prove always runs. It does: `http_mime()` never returns NULL — an unknown extension falls back to `default_mime = {"txt","text/plain",0}`, i.e. exactly the `"r"` the initializer now spells out. Verified on MVS (STC 603): a `.zzq` file serves `200 text/plain` with the right body and length.

`progLen` in `httpstrt.c`/`cgistart.c` is assigned and read under the same `GRTFLAG1_TSO` test, which GCC cannot correlate. `httpcred.c`'s `rc` is only read unwritten if the static `head[]` array were empty. Both get an explicit initializer and a comment.

## Also

`httpx.c:61` had a nested `/*` inside a disabled vector entry's comment. `httpdsld.c:9,10` initialized two structs whose first member is an aggregate with `{0}` instead of `{{0}}`. Neither changes the vector layout or the zeroing.

## Explicitly deferred

The **18 `subscript has type 'char'`** warnings are not here. On EBCDIC with signed `char`, a set high bit indexes negatively — but a blanket `(unsigned char)` cast is only correct after checking each table's declared size, and eight of them are in `httpfile.c` alone. They get their own PR: it is the one bucket where the fix itself could introduce a bug.

## Verification

- `make` clean under cc370, all 6 modules link.
- `make test-host`: 63 assertions pass.
- Warnings: **251 → 220**, and every category this PR targets is at zero (implicit declarations, format mismatches, uninitialized, missing braces, nested comment).
- Not verified on MVS: `httpopen.c` and the two format-string paths are the ones worth exercising there — an unknown file extension through the UFS docroot, and invoking HTTPDSL from TSO.