### PR TITLE
Pass ctype macros an unsigned char, not a plain char

### DIFF
--- a/src/httpd.c
+++ b/src/httpd.c
@@ -67,7 +67,7 @@ initialize(int argc, char **argv)
 		// wtof("%s: argv[%d]=\"%s\"", __func__, i, argv[i]);
 		if (memcmp(argv[i], "CONFIG=", 7)==0) {
 			config = &argv[i][7];
-			while(*config=='=' || isspace(*config)) config++; 
+			while(*config=='=' || isspace((unsigned char)*config)) config++; 
 			if (!*config) config = "CONFIG";
 		}
 	}

--- a/src/httpdsl.c
+++ b/src/httpdsl.c
@@ -296,7 +296,7 @@ do_print_text(HTTPDS *ds)
     while(fgets(buf, len, fp)) {
         /* map any non-printable characters to spaces */
         for(i=0; i < len; i++) {
-            if (isprint(buf[i])) continue;
+            if (isprint((unsigned char)buf[i])) continue;
             if (buf[i]=='\n' && buf[i+1]==0) {
                 i++;
                 break;
@@ -368,7 +368,7 @@ isdataset(const char *name)
 	
 	if (ismember(buf)) {
 		/* looks like a single high level qualifier */
-		if (!isdigit(buf[0])) {
+		if (!isdigit((unsigned char)buf[0])) {
 			dataset = 1;
 			goto quit;
 		}
@@ -393,7 +393,7 @@ isdataset(const char *name)
 		
 		if (len < 1) goto quit;			/* dataset level name too short */
 		if (len > 8) goto quit;			/* dataset level name too long */
-		if (isdigit(p[0])) goto quit;	/* dataset level name can not start with a number */
+		if (isdigit((unsigned char)p[0])) goto quit;	/* dataset level name can not start with a number */
 		if (!ismember(p)) goto quit;	/* bad character in name */
 
 		if (lparen && rparen) {
@@ -441,7 +441,7 @@ ismember(const char *name)
 			if (name[i]=='@') continue;
 			if (name[i]=='#') continue;
 			if (name[i]=='$') continue;
-			if (isalnum(name[i])) continue;
+			if (isalnum((unsigned char)name[i])) continue;
 
 			/* not a valid character for a member name */
 			member = 0;
@@ -472,8 +472,8 @@ strupper(char *buf)
 	if (!buf) goto quit;
 	
 	for(i=0; buf[i]; i++) {
-		if (islower(buf[i])) {
-			buf[i] = (char) toupper(buf[i]);
+		if (islower((unsigned char)buf[i])) {
+			buf[i] = (char) toupper((unsigned char)buf[i]);
 		}
 	}
 

--- a/src/httpfile.c
+++ b/src/httpfile.c
@@ -280,7 +280,7 @@ ssi_process(HTTPC *httpc, char *ssi)
 	save[sizeof(save)-1] = 0;
 
     p = &ssi[5];				/* skip over "<!--#" */
-	while (isspace(*p)) p++;	/* skip any white space */
+	while (isspace((unsigned char)*p)) p++;	/* skip any white space */
 	if (!*p) goto invalid;
 
 	/* isolate the ssi request (split at first space) */
@@ -288,7 +288,7 @@ ssi_process(HTTPC *httpc, char *ssi)
 	while (*next && *next != ' ') next++;
 	if (!*next) goto invalid;
 	*next++ = 0;
-	while (isspace(*next)) next++;
+	while (isspace((unsigned char)*next)) next++;
 	if (!*next) goto invalid;
 
 	if (http_cmp(p, "echo")==0) {
@@ -373,7 +373,7 @@ ssi_echo(HTTPC *httpc, char *next)
 
 	// wtof("%s: enter next=\"%s\"", __func__, next);
 
-	while(isspace(*next)) next++;
+	while(isspace((unsigned char)*next)) next++;
 	
 	p = strchr(next, '=');
 	if (!p) goto bad;
@@ -381,7 +381,7 @@ ssi_echo(HTTPC *httpc, char *next)
 
 	if (http_cmp(next, "var")!=0) goto bad;
 
-	while(isspace(*p)) p++;
+	while(isspace((unsigned char)*p)) p++;
 	
 	/* extract quoted value — skip opening quote */
 	if (*p == '"' || *p == '\'') p++;
@@ -390,7 +390,7 @@ ssi_echo(HTTPC *httpc, char *next)
 	*p = 0;
 	if (!var || !*var) goto quit;
 	
-	while(isspace(*var)) var++;
+	while(isspace((unsigned char)*var)) var++;
 
 	p = http_get_env(httpc, var);
 	if (!p) p = getenv(var);
@@ -497,7 +497,7 @@ ssi_include(HTTPC *httpc, char *next)
 		goto quit;
 	}
 
-	while(isspace(*next)) next++;
+	while(isspace((unsigned char)*next)) next++;
 	
 	p = strchr(next, '=');
 	if (!p) goto bad;
@@ -509,7 +509,7 @@ ssi_include(HTTPC *httpc, char *next)
 	/* we're going to treat virtual and file the same way for now */
 	if (!isvirtual && !isfile) goto bad;
 
-	while(isspace(*p)) p++;
+	while(isspace((unsigned char)*p)) p++;
 	
 	/* extract quoted path — skip opening quote */
 	if (*p == '"' || *p == '\'') p++;
@@ -518,7 +518,7 @@ ssi_include(HTTPC *httpc, char *next)
 	*p = 0;
 	if (!*path) goto bad;
 	
-	while(isspace(*path)) path++;
+	while(isspace((unsigned char)*path)) path++;
 
 	/* save the path as uri in case of failure to open path */
 	strncpy(uri, path, sizeof(uri));

--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -171,7 +171,7 @@ do_status(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid, in
 
     if (cp && cp->buf) {
         for(i=0; i < sizeof(jesinfo); i++) {
-            if (!isprint(cp->buf[i]) || cp->buf[i]=='\\' || cp->buf[i]=='"') {
+            if (!isprint((unsigned char)cp->buf[i]) || cp->buf[i]=='\\' || cp->buf[i]=='"') {
                 jesinfo[i] = '.';
                 continue;
             }
@@ -510,7 +510,7 @@ do_print(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid)
         if (http_cmp(p, "yes")==0 || http_cmp(p, "true")==0) {
             download = 1;
         }
-        else if (isdigit(*p)) {
+        else if (isdigit((unsigned char)*p)) {
             download = atoi(p);
         }
     }

--- a/src/jesst.c
+++ b/src/jesst.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
         if (p) {
             if (http_cmp(p, "yes")==0) dd = 1;
             else if (http_cmp(p, "true")==0) dd=1;
-            else if (isdigit(*p)) dd = atoi(p);
+            else if (isdigit((unsigned char)*p)) dd = atoi(p);
         }
     }
     else if (argc > 1) {


### PR DESCRIPTION
Third of five staged PRs for #138. **220 → 202** warnings, and `cc370 -O1 -S` over all 114 translation units is byte-identical before and after.

## What the 18 warnings are

All the same shape — a `ctype.h` macro applied to a plain `char`:

```c
isspace(*p)      isprint(buf[i])   isdigit(p[0])
isalnum(name[i]) islower(buf[i])   toupper(buf[i])
```

8 in `httpfile.c`, 6 in `httpdsl.c`, 2 in `httpjes2.c`, 1 each in `httpd.c` and `jesst.c`.

libc370 implements them as a table index:

```c
#define isspace(c) (__isbuf[(c)] & 0x0100U)
```

over

```c
static unsigned short __isbufR[257] = { ... };
unsigned short *__isbuf = &__isbufR[1];
```

so the valid index range is **−1 through 255**, the −1 slot existing for `EOF`.

## They are not live defects here — checked, not assumed

`cc370 -E -dM` reports `__CHAR_UNSIGNED__ 1`. A plain `char` on this target holds 0..255, so every one of these 18 indices lands in range. Nothing is broken today, and this PR fixes no bug.

I am stating that plainly because I have twice in this series described a `-Wall` finding as a live bug and been wrong (see the corrections on #140). The check came first this time.

## Why change them anyway

The dormancy is unusually thin, and EBCDIC is what makes it thin.

In CP037 every letter and every digit sits at or above `0x80` — `'a'` is `0x81`, `'z'` is `0xA9`, `'0'` is `0xF0`, `'9'` is `0xF9`. If `char` were signed, `isspace('a')` would evaluate `__isbuf[-127]` — a read 254 bytes before the table — on the most ordinary input the server handles. Not an edge case: the *common* case.

The only thing standing between that and today's build is cc370 defaulting to unsigned `char`. `-fsigned-char` on its own would be enough, as would a toolchain change. The cast states the requirement rather than inheriting it from a compiler default, and it is what `-Werror` needs regardless.

## Why not fix it inside libc370's macros

Because `(unsigned char)(-1)` is `255`. Casting inside the macro would fold `EOF` onto a real character and make the `__isbufR[0]` slot pointless. The C contract puts the cast at the call site — an argument must be representable as `unsigned char`, or be `EOF` — which is where it now is.

## Verification

- **Byte-identical assembler across all 114 TUs**, which is the expected result when `char` is already unsigned and the cast is a no-op.
- `make` clean under cc370, all 6 modules link.
- `make test-host`: 63 assertions pass.
- `-Wchar-subscripts` count: **18 → 0**.

Nothing to verify on MVS: with identical object code there is no runtime behaviour to exercise.

## Remaining after this

| count | warning | PR |
|---:|---|---|
| 92 | `suggest parentheses around assignment used as truth value` | 4 |
| 57 | `unused variable` | 4 |
| 40 | `label defined but not used` | 4 |
| 8 | `declared static but never defined` | 4 |
| 5 | `defined but not used` | 4 |

Then PR 5 turns on `-Wall -Werror` in `project.toml`, which is what #138 is for.