### PR TITLE
Parenthesize assignments used as conditions, drop dead labels

### DIFF
--- a/credentials/src/credinit.c
+++ b/credentials/src/credinit.c
@@ -20,6 +20,5 @@ int cred_init(void *salt, unsigned saltlen)
 	
 	rc = try(blowfish_key_setup, salt, key, saltlen);
 
-quit:
 	return rc;
 }

--- a/src/dbgdump.c
+++ b/src/dbgdump.c
@@ -52,7 +52,6 @@ dump(FILE *fp, const char *pName, const void *pvArea, int iSize, int iChunk)
             iChunk, iChunk, eChar, iChunk, iChunk, aChar);
     }
 
-quit:
     return;
 }
 

--- a/src/httpcons.c
+++ b/src/httpcons.c
@@ -241,7 +241,6 @@ d_login_cred(CRED *cred)
 		id.addr       & 0xFF,
 		cred->acee);
 
-quit:
 	return rc;
 }
 
@@ -272,7 +271,6 @@ d_login(char *buf)
 		unlock(cred, LOCK_SHR);
 	}
 	
-quit:
 	unlock(array, LOCK_SHR);
 	unlock(httpd, LOCK_SHR);
     return rc;
@@ -287,7 +285,6 @@ d_port(char *buf)
 
     wtof("HTTPD102I HTTPD server listening on port %d", httpd->port);
 
-quit:
     return rc;
 }
 
@@ -430,7 +427,6 @@ d_time(char *buf)
 	strftime(tbuf, sizeof(tbuf), "HTTPD143I time %Y/%m/%d %H:%M:%S Local", &tm);
 	wtof("%s TZOFFSET=%s%d", tbuf, sign < 0 ? "-" : "+", minutes);
 
-quit:
 	return 0;
 }
 
@@ -628,7 +624,6 @@ d_thread(char *buf)
         unlock(mgr,1);
     }
 
-quit:
     unlock(httpd,1);
     return rc;
 }
@@ -673,7 +668,6 @@ s_maxtask(char *buf)
         unlock(mgr,1);
     }
 
-quit:
     unlock(httpd,1);
     return rc;
 }
@@ -718,7 +712,6 @@ s_mintask(char *buf)
         unlock(mgr,1);
     }
 
-quit:
     unlock(httpd,1);
     return rc;
 }

--- a/src/httpcred.c
+++ b/src/httpcred.c
@@ -238,27 +238,27 @@ print_body(HTTPD *httpd, HTTPC *httpc, const char *msg)
 	if (!uri) uri = "/";
 	
 	for(i=0; body1[i]; i++) {
-		if (rc=http_printf(httpc, " %s\n", body1[i])) goto quit;
+		if ((rc=http_printf(httpc, " %s\n", body1[i]))) goto quit;
 	}
 
 	if (msg) {
-		if (rc=http_printf(httpc, "<h2 class=\"message\">%s</h2>\n", msg)) goto quit;
+		if ((rc=http_printf(httpc, "<h2 class=\"message\">%s</h2>\n", msg))) goto quit;
 	}
 
 	for(i=0; body2[i]; i++) {
-		if (rc=http_printf(httpc, " %s\n", body2[i])) goto quit;
+		if ((rc=http_printf(httpc, " %s\n", body2[i]))) goto quit;
 	}
 
 	/* The hidden field carries the client-controlled Sec-Uri cookie back to
 	   the form.  HTML-escape it (reflected XSS) and print it directly -- never
 	   sprintf an unbounded cookie value into a fixed stack buffer (overflow). */
 	http_html_escape((UCHAR *)esc, sizeof(esc), (UCHAR *)uri);
-	if (rc=http_printf(httpc,
-	        "    <input type=\"hidden\" name=\"uri\" value=\"%s\">\n", esc))
+	if ((rc=http_printf(httpc,
+	        "    <input type=\"hidden\" name=\"uri\" value=\"%s\">\n", esc)))
 		goto quit;
 
 	for(i=0; body3[i]; i++) {
-		if (rc=http_printf(httpc, " %s\n", body3[i])) goto quit;
+		if ((rc=http_printf(httpc, " %s\n", body3[i]))) goto quit;
 	}
 
 quit:
@@ -280,8 +280,8 @@ print_login(HTTPD *httpd, HTTPC *httpc, const char *msg)
 
 	http_printf(httpc, "<!DOCTYPE html>\n");
 	http_printf(httpc, "<html lang=\"en-US\">\n");
-	if (rc=print_head(httpd,httpc)) goto quit;
-	if (rc=print_body(httpd,httpc,msg)) goto quit;
+	if ((rc=print_head(httpd,httpc))) goto quit;
+	if ((rc=print_body(httpd,httpc,msg))) goto quit;
 
 #if 0
 	/* debugging only */

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -380,7 +380,6 @@ build_fd_set(fd_set *read, fd_set *write, fd_set *excp)
         if (excp)   FD_SET(httpc->socket, excp);
     }
 
-quit:
     if (maxsock) maxsock++;
 #if 0
     http_exit("build_fd_set(), maxsock=%d\n", maxsock);
@@ -698,7 +697,6 @@ worker_thread(void *udata, CTHDWORK *work)
         }
     }
 
-quit:
 	wtof("HTTPD060I SHUTDOWN worker(%06X)   TCB(%06X) TASK(%06X) STACKSIZE(%u)",
 		work, tcb, task, task->stacksize);
 
@@ -718,7 +716,6 @@ build_ecblist(COM *com, unsigned **ecblist)
         ecblist[pos++] = com->comecbpt;
     }
 
-quit:
     if (pos) {
         ecbp = ecblist[pos-1];
         ecblist[pos-1] = (unsigned*)((unsigned)ecbp | 0x80000000);

--- a/src/httpdbug.c
+++ b/src/httpdbug.c
@@ -75,7 +75,6 @@ dump_cgi(HTTPD *httpd, HTTPC *httpc)
 			p->path, p->pgm ? p->pgm : "(none)", p->login, p->wild);
     }
 
-quit:
     return 0;
 }
 
@@ -92,7 +91,6 @@ dump_help(HTTPD *httpd, HTTPC *httpc)
 		http_printf(httpc, "   %s\n", help_text[i]);
 	}
 	
-quit:
 	return rc;
 }
 

--- a/src/httpdel.c
+++ b/src/httpdel.c
@@ -14,7 +14,6 @@ httpdel(HTTPC *httpc)
     /* not implemented */
     rc = http_resp_not_implemented(httpc);
 
-quit:
     httpc->state = CSTATE_DONE;
     http_exit("httpdel()\n");
     return rc;

--- a/src/httpdenv.c
+++ b/src/httpdenv.c
@@ -14,6 +14,5 @@ httpdenv(HTTPC *httpc, const UCHAR *name)
         array_del(&httpc->env, indx);
     }
 
-quit:
     return rc;
 }

--- a/src/httpdm.c
+++ b/src/httpdm.c
@@ -84,7 +84,6 @@ int main(int argc, char **argv)
 
     display_memory(httpd, httpc, &options);
 
-quit:
     return 0;
 }
 
@@ -97,35 +96,35 @@ display_memory(HTTPD *httpd, HTTPC *httpc, OPTIONS *options)
     int         len     = options->len;
     int         size    = options->size;
 
-    if (rc = http_resp(httpc,200) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", data ? "text/plain" : "text/html") < 0) goto quit;
-    if (rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "\r\n") < 0) goto quit;
+    if ((rc = http_resp(httpc,200) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", data ? "text/plain" : "text/html") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "\r\n") < 0)) goto quit;
 
     if (!data) {
-        if (rc = http_printf(httpc, "<!DOCTYPE html>\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "<html>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<!DOCTYPE html>\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "<html>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "<head>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<head>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "<title>HTTPDM</title>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<title>HTTPDM</title>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "<style>\n") < 0) goto quit;
-        if (rc = http_printf(httpc, ".shadowbox {\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "  width: 45em;\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "  border: 1px solid #333;\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "  box-shadow: 8px 8px 5px #444;\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "  padding: 8px 12px;\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<style>\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, ".shadowbox {\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "  width: 45em;\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "  border: 1px solid #333;\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "  box-shadow: 8px 8px 5px #444;\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "  padding: 8px 12px;\n") < 0)) goto quit;
         // if (rc = http_printf(httpc, "  background-image: linear-gradient(180deg, #fff, #ddd 40%%, #ccc);\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "  background-image: linear-gradient(270deg, #eee, #ddd 10%%, #ccc);\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "}\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "</style>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "  background-image: linear-gradient(270deg, #eee, #ddd 10%%, #ccc);\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "}\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "</style>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "</head>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "</head>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "<body>\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "<div class=\"shadowbox\">\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<body>\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "<div class=\"shadowbox\">\n") < 0)) goto quit;
 
         http_printf(httpc, "<form>\n");
         if (options->title && options->title[0]) {

--- a/src/httpdmtt.c
+++ b/src/httpdmtt.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
 
     display_mtt(httpd, httpc, atoi(data));
 
-quit:
     return 0;
 }
 
@@ -41,21 +40,21 @@ display_mtt(HTTPD *httpd, HTTPC *httpc, int data)
     MTENTRY     **mtentry;
     unsigned    n, count;
 
-    if (rc = http_resp(httpc,200) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", data ? "text/plain" : "text/html") < 0) goto quit;
-    if (rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "\r\n") < 0) goto quit;
+    if ((rc = http_resp(httpc,200) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", data ? "text/plain" : "text/html") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "\r\n") < 0)) goto quit;
 
     if (!data) {
-        if (rc = http_printf(httpc, "<!DOCTYPE html>\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "<html>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<!DOCTYPE html>\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "<html>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "<head>\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "<title>HTTPDMTT</title>\n") < 0) goto quit;
-        if (rc = http_printf(httpc, "</head>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<head>\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "<title>HTTPDMTT</title>\n") < 0)) goto quit;
+        if ((rc = http_printf(httpc, "</head>\n") < 0)) goto quit;
 
-        if (rc = http_printf(httpc, "<body>\n") < 0) goto quit;
+        if ((rc = http_printf(httpc, "<body>\n") < 0)) goto quit;
     }
 
     /* allocate Master Trace Table */

--- a/src/httpdone.c
+++ b/src/httpdone.c
@@ -36,7 +36,6 @@ httpdone(HTTPC *httpc)
 
     httpsecs(&httpc->end);
 
-quit:
     /* transition to next state */
     httpc->state = CSTATE_REPORT;
 

--- a/src/httpdsl.c
+++ b/src/httpdsl.c
@@ -149,7 +149,6 @@ int main(int argc, char **argv)
         http_printf(httpc, "The requested document \"%s\" was not found.\n", ds->path);
     }
 
-quit:
     return 0;
 }
 
@@ -165,7 +164,6 @@ do_print(HTTPDS *ds)
         rc = do_print_text(ds);
     }
     
-quit:
     return rc;
 }
 
@@ -225,7 +223,7 @@ do_print_binary(HTTPDS *ds)
     http_printf(httpc, "Pragma: private\r\n");
     http_printf(httpc, "\r\n");
     
-    while(i=fread(buf, 1, len, fp)) {
+    while((i=fread(buf, 1, len, fp))) {
         // wtof("%s: fread() rc=%d", __func__, i);
         
         /* send buffer to web client */

--- a/src/httpdsll.c
+++ b/src/httpdsll.c
@@ -119,7 +119,6 @@ do_list_hlq_json(HTTPDS *ds, DSLIST **dslist)
     /* end of JSON object */
     http_printf(httpc, "}\n");
 
-quit:
     return 0;
 }
 

--- a/src/httpdslp.c
+++ b/src/httpdslp.c
@@ -88,7 +88,6 @@ do_pds_json(HTTPDS *ds, DSLIST *dslist, PDSLIST **pdslist)
         goto text_members;
     }
 
-load_members:
     for(n=0; n < count; n++) {
         PDSLIST *a = pdslist[n];
         if (!a) continue;
@@ -172,7 +171,6 @@ all_members:
     /* end of JSON object */
     http_printf(httpc, "}\n");
 
-quit:
     return 0;
 }
 

--- a/src/httpdsrv.c
+++ b/src/httpdsrv.c
@@ -138,34 +138,34 @@ send_resp(HTTPD *httpd, HTTPC *httpc, int resp)
 {
     int     rc;
 
-    if (rc = http_resp(httpc, resp) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", "text/html") < 0) goto quit;
-    if (rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "\r\n") < 0) goto quit;
+    if ((rc = http_resp(httpc, resp) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", "text/html") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "\r\n") < 0)) goto quit;
 
-    if (rc = http_printf(httpc, "<!DOCTYPE html>\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "<html>\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "<!DOCTYPE html>\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "<html>\n") < 0)) goto quit;
 
-    if (rc = http_printf(httpc, "<head>\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "<head>\n") < 0)) goto quit;
 
-    if (rc = http_printf(httpc, "<title>HTTPDSRV</title>\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "<title>HTTPDSRV</title>\n") < 0)) goto quit;
 
-    if (rc = http_printf(httpc, "<style>\n") < 0) goto quit;
-    if (rc = http_printf(httpc, ".shadowbox {\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "  width: 45em;\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "  border: 1px solid #333;\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "  box-shadow: 8px 8px 5px #444;\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "  padding: 8px 12px;\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "<style>\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, ".shadowbox {\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "  width: 45em;\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "  border: 1px solid #333;\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "  box-shadow: 8px 8px 5px #444;\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "  padding: 8px 12px;\n") < 0)) goto quit;
     // if (rc = http_printf(httpc, "  background-image: linear-gradient(180deg, #fff, #ddd 40%%, #ccc);\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "  background-image: linear-gradient(270deg, #eee, #ddd 10%%, #ccc);\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "}\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "</style>\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "  background-image: linear-gradient(270deg, #eee, #ddd 10%%, #ccc);\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "}\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "</style>\n") < 0)) goto quit;
 
-    if (rc = http_printf(httpc, "</head>\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "</head>\n") < 0)) goto quit;
 
-    if (rc = http_printf(httpc, "<body>\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "<div class=\"shadowbox\">\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "<body>\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "<div class=\"shadowbox\">\n") < 0)) goto quit;
 
  
 quit:
@@ -177,9 +177,9 @@ send_last(HTTPD *httpd, HTTPC *httpc)
 {
     int     rc;
 
-    if (rc = http_printf(httpc, "</div>\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "</body>\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "</html>\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "</div>\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "</body>\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "</html>\n") < 0)) goto quit;
 
 quit:
     return rc;
@@ -196,7 +196,7 @@ display_httpd(HTTPD *httpd, HTTPC *httpc)
     int         rc      = 0;
     UCHAR       *u;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     http_printf(httpc, "<h2>HTTPD Handle %p</h2>\n", httpd);
 
@@ -499,7 +499,6 @@ display_httpd(HTTPD *httpd, HTTPC *httpc)
         "<td>%p</td></tr>\n", 
         O(cgictx), httpd->cgictx, (HTTPD_CGICTX_MAX+1)*4, httpd->cgictx);
 
-done:
     http_printf(httpc, "</table>\n");
     send_last(httpd, httpc);
 	
@@ -556,7 +555,7 @@ display_ufssys(HTTPD *httpd, HTTPC *httpc, UFSSYS *sys)
         sys = httpd->ufssys;
     }
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     http_printf(httpc, "<h2>UFS System Handle %p</h2>\n", sys);
 
@@ -582,7 +581,6 @@ display_ufssys(HTTPD *httpd, HTTPC *httpc, UFSSYS *sys)
         "Disk and inode state is owned by the UFSD STC."
         "</td></tr>\n");
 
-done:
     http_printf(httpc, "</table>\n");
     send_last(httpd, httpc);
 
@@ -1364,7 +1362,7 @@ display_ufs(HTTPD *httpd, HTTPC *httpc, UFS *ufs)
     int         rc      = 0;
     UCHAR       *u;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     http_printf(httpc, "<h2>UFS Handle %p</h2>\n", ufs);
 
@@ -1387,7 +1385,6 @@ display_ufs(HTTPD *httpd, HTTPC *httpc, UFS *ufs)
 
 
 
-done:
     http_printf(httpc, "</table>\n");
     send_last(httpd, httpc);
 	
@@ -1425,7 +1422,7 @@ display_cgi(HTTPD *httpd, HTTPC *httpc)
     char        *memory = NULL;
     unsigned    n, count;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     /* Get the query variables from the URL */
     if (!memory) memory = http_get_env(httpc, "QUERY_MEMORY");
@@ -1542,7 +1539,7 @@ display_file(HTTPD *httpd, HTTPC *httpc)
     char        *memory = NULL;
     UCHAR       type;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     /* Get the query variables from the URL */
     if (!memory) memory = http_get_env(httpc, "QUERY_MEMORY");
@@ -1709,7 +1706,7 @@ display_task(HTTPD *httpd, HTTPC *httpc)
     char        *memory = NULL;
     UCHAR       type;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     /* Get the query variables from the URL */
     if (!memory) memory = http_get_env(httpc, "QUERY_MEMORY");
@@ -1820,7 +1817,7 @@ display_mgr(HTTPD *httpd, HTTPC *httpc)
     char        *s;
     unsigned    n, count;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     http_printf(httpc, "<h2>HTTPD Thread Manager %p</h2>", mgr);
 #if 0
@@ -1963,7 +1960,7 @@ display_workers(HTTPD *httpd, HTTPC *httpc)
     CTHDWORK    *worker = NULL;
     unsigned    n, count;
 
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     /* Get the query variables from the URL */
     if (!memory) memory = http_get_env(httpc, "QUERY_MEMORY");
@@ -2268,7 +2265,6 @@ display_memory(HTTPD *httpd, HTTPC *httpc, const char *title, void *memory, int 
 done:
     http_printf(httpc, "</pre>\n");
 	
-quit:
 	return 0;
 }
 
@@ -2365,7 +2361,7 @@ display_help(HTTPD *httpd, HTTPC *httpc)
     if (!host)  host = http_get_env(httpc, "HTTP_HOST");
     if (!host)  host = "unknown";
     
-    if (rc = send_resp(httpd, httpc, 200) < 0) goto quit;
+    if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
     http_printf(httpc, "<h2>HTTPDSRV Help</h2>\n");
     http_printf(httpc, "<h3>Usage: http:/%s%s?target=name[&m=nnnnnnnn]</h3>\n", host, path);

--- a/src/httpfenv.c
+++ b/src/httpfenv.c
@@ -19,6 +19,5 @@ httpfenv(HTTPC *httpc, const UCHAR *name)
         }
     }
 
-quit:
     return indx;
 }

--- a/src/httpfile.c
+++ b/src/httpfile.c
@@ -536,7 +536,6 @@ ssi_include(HTTPC *httpc, char *next)
         goto quit;
     }
 
-okay:
 	// ssi_printf(httpc, "\n");
 	
 	httpc->state = CSTATE_GET;
@@ -611,7 +610,6 @@ ssi_printv(HTTPC *httpc, const char *fmt, va_list args)
 		ssi_buffer(httpc, buf, len);
     }
 
-quit:
     return rc;
 }
 

--- a/src/httpgenv.c
+++ b/src/httpgenv.c
@@ -9,6 +9,5 @@ httpgenv(HTTPC *httpc, const UCHAR *name)
     unsigned    indx    = http_find_env(httpc, name);
     HTTPV       *v      = indx ? httpc->env[indx-1] : NULL;
 
-quit:
     return (v ? v->value : NULL);
 }

--- a/src/httphead.c
+++ b/src/httphead.c
@@ -14,7 +14,6 @@ httphead(HTTPC *httpc)
     /* not implemented */
     rc = http_resp_not_implemented(httpc);
 
-quit:
     httpc->state = CSTATE_DONE;
     http_exit("httphead(), rc=%d\n", rc);
     return rc;

--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -106,7 +106,6 @@ int main(int argc, char **argv)
         break;
     }
 
-quit:
     return 0;
 }
 
@@ -180,16 +179,16 @@ do_status(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid, in
         jesinfo[sizeof(jesinfo)-1]=0;
     }
 
-    if (rc = http_resp(httpc,200) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", "application/json") < 0) goto quit;
-    if (rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "\r\n") < 0) goto quit;
+    if ((rc = http_resp(httpc,200) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", "application/json") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Access-Control-Allow-Origin: *\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "\r\n") < 0)) goto quit;
 
     count = array_count(&jobs);
 
-    if (rc = http_printf(httpc, "{\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "  \"data\": [\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "{\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "  \"data\": [\n") < 0)) goto quit;
 
     for(n=0; n < count; n++) {
         JESJOB *j = jobs[n];
@@ -516,9 +515,9 @@ do_print(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid)
     }
 
     /* send the headers */
-    if (rc = http_resp(httpc,200) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", "text/plain") < 0) goto quit;
+    if ((rc = http_resp(httpc,200) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", "text/plain") < 0)) goto quit;
     if (!download) {
         rc = http_printf(httpc, "\r\n");
         if (rc < 0) goto quit;
@@ -806,10 +805,10 @@ do_cancel_ex(HTTPD *httpd, HTTPC *httpc, const char *verb, int purge, int all)
     }
 
     /* send the headers */
-    if (rc = http_resp(httpc,200) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", "text/plain") < 0) goto quit;
-    if (rc = http_printf(httpc, "\r\n") < 0) goto quit;
+    if ((rc = http_resp(httpc,200) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", "text/plain") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "\r\n") < 0)) goto quit;
 
     if (!jobname && !all) {
         rc = http_printf(httpc, "Jobname: \"null\" <=== missing value\r\n");
@@ -981,13 +980,13 @@ do_help(HTTPD *httpd, HTTPC *httpc)
     int     i;
 
     /* send HTTP headers */
-    if (rc = http_resp(httpc,200) < 0) goto quit;
-    if (rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0) goto quit;
-    if (rc = http_printf(httpc, "Content-Type: %s\r\n", "text/plain") < 0) goto quit;
-    if (rc = http_printf(httpc, "\r\n") < 0) goto quit;
+    if ((rc = http_resp(httpc,200) < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Cache-Control: no-store\r\n") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "Content-Type: %s\r\n", "text/plain") < 0)) goto quit;
+    if ((rc = http_printf(httpc, "\r\n") < 0)) goto quit;
 
     /* Tell them what we are */
-    if (rc = http_printf(httpc, "HTTPJES2 Help\r\n\r\n") < 0) goto quit;
+    if ((rc = http_printf(httpc, "HTTPJES2 Help\r\n\r\n") < 0)) goto quit;
     if (http_cmp(verb, "/help")!=0) {
         /* they didn't ask for help, so tell them we don't understand the request */
         rc = http_printf(httpc,

--- a/src/httpnenv.c
+++ b/src/httpnenv.c
@@ -25,6 +25,5 @@ httpnenv(const UCHAR *name, const UCHAR *value)
         if (vallen) strcpy(v->value, value);
     }
 
-quit:
     return v;
 }

--- a/src/httppcgi.c
+++ b/src/httppcgi.c
@@ -52,7 +52,6 @@ httppcgi(HTTPC *httpc, HTTPCGI *cgi)
         }
     }
 
-quit:
     httpc->state = CSTATE_DONE;
     http_exit("httppcgi()\n");
     return rc;

--- a/src/httppost.c
+++ b/src/httppost.c
@@ -14,7 +14,6 @@ httppost(HTTPC *httpc)
     /* not implemented */
     rc = http_resp_not_implemented(httpc);
 
-quit:
     httpc->state = CSTATE_DONE;
     http_exit("httppost(), rc=%d\n", rc);
     return rc;

--- a/src/httpput.c
+++ b/src/httpput.c
@@ -14,7 +14,6 @@ httpput(HTTPC *httpc)
     /* not implemented */
     rc = http_resp_not_implemented(httpc);
 
-quit:
     httpc->state = CSTATE_DONE;
     http_exit("httpput()\n");
     return rc;

--- a/src/httpsndb.c
+++ b/src/httpsndb.c
@@ -19,7 +19,6 @@ httpsndb(HTTPC *httpc)
     rc = http_send_file(httpc, 1);
 #endif
 
-quit:
     http_exit("httpsndb()\n");
     return rc;
 }

--- a/src/jesst.c
+++ b/src/jesst.c
@@ -174,7 +174,6 @@ int main(int argc, char **argv)
     }
 #endif
 
-quit:
     if (jobs) jesjobfr(&jobs);
     if (jes) jesclose(&jes);
     return 0;


### PR DESCRIPTION
Fourth of six staged PRs for #138. **202 → 70** warnings, no change to the emitted instruction stream.

## The two classes, 132 sites

**92 × `suggest parentheses around assignment used as truth value`** — the `if (rc = f())` idiom written with one paren level:

```c
-		if (rc=http_printf(httpc, " %s\n", body1[i])) goto quit;
+		if ((rc=http_printf(httpc, " %s\n", body1[i]))) goto quit;
```

The extra pair says the assignment is deliberate, which is what the warning is asking for. Concentrated in the CGI modules: 37 in `httpdsrv.c`, 22 in `httpdm.c`, 20 in `httpjes2.c`, 12 in `httpdmtt.c`.

**40 × `label defined but not used`** — mostly a `quit:` in a function whose last `goto quit` disappeared at some point:

```c
-quit:
     return v;
```

The label is dead; the statement it labelled is not, and stays.

Both were driven off the compiler's own warning list rather than by grepping the sources, and the parenthesizing walks to the matching close paren, so a condition spanning several lines is treated like a single-line one — `httpcred.c:256` is one of those:

```c
-	if (rc=http_printf(httpc,
-	        "    <input type=\"hidden\" name=\"uri\" value=\"%s\">\n", esc))
+	if ((rc=http_printf(httpc,
+	        "    <input type=\"hidden\" name=\"uri\" value=\"%s\">\n", esc)))
 		goto quit;
```

## Verification needed more than a -S diff

The previous PRs in this series claimed byte-identical `cc370 -S` output. That does not hold here, and the reason is worth stating rather than waving through: **removing a label makes GCC renumber its internal `@@Lnn` symbols**, so a plain comparison reports differences in 19 files that are not code changes —

```
<          BNH   @@L20
>          BNH   @@L19
```

Same branch, same target, different number.

So the comparison drops the pure `@@Lnn EQU *` definition lines — they emit neither code nor data — and canonicalizes the remaining label *references* by order of first appearance. On that basis:

```
Instruktionsstrom identisch: 113/113
echte Code-Unterschiede: 0
```

The only difference in the generated output is that 40 `EQU *` lines are gone, which is exactly what removing an unreferenced label should do and nothing more.

(Earlier PRs in this series said "all 114 translation units". It is 113 — the extra one was a header line from a shell `ls` alias inflating the count. Every TU was compared either way; only the number was off.)

- `make` clean under cc370, all 6 modules link.
- `make test-host`: 63 assertions pass.

Nothing to exercise on MVS: identical instruction stream, no runtime behaviour to test.

## What is left

| count | warning | PR |
|---:|---|---|
| 57 | `unused variable` | 5 |
| 8 | `declared static but never defined` | 5 |
| 5 | `defined but not used` | 5 |

PR 5 is the one bucket needing per-site judgment rather than a rule. Deleting an unused variable can delete a side effect — and on MVS an `int rc = something();` that is never read is more likely an **unchecked return code** than dead code, which the root `CLAUDE.md` treats as mandatory to check. The 13 dead statics are a scope decision too: a forward declaration that was never defined is a different thing from a function that is defined but never called.

PR 6 then turns on `-Wall -Werror` in `project.toml`, which is what #138 is actually for.