### PR TITLE
Document the display modules as a debugging tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,3 +274,51 @@ tests/curl-jobs.sh        # Jobs API
 tests/curl-uss.sh         # USS/UFS API
 tests/test.sh             # Top-level runner
 ```
+
+### Display Modules (live storage inspection)
+
+The root `CLAUDE.md` covers when to reach for these; this is the detail. All are
+read-only, all need Basic auth, none is registered unless `DD:HTTPDPRM` says so.
+
+**`/.dsrv` — HTTPDSRV, server control blocks.** `?target=` selects the block and
+each one is shown as hex plus a named field table:
+
+| target | block | needs `&m=` |
+|--------|-------|-------------|
+| `HTTPD` | the server singleton (320 bytes, `0x140`) | no |
+| `MGR` | `CTHDMGR`, the worker pool manager | no |
+| `FS` | `UFSSYS` handle (8 bytes with the libufs stub) | no |
+| `CGI` | one `HTTPCGI` route, or the route array | **yes** |
+| `TASK` | a `CTHDTASK` | **yes** |
+| `FILE` | a `FILE` handle | **yes** |
+
+The addresses the `&m=` targets want come out of the `HTTPD` block:
+`httpcgi` at `+44`, `mgr` at `+34`, `socket_thread` at `+30`, `ufssys` at `+54`.
+
+**`/.dm` — HTTPDM, arbitrary storage.** `?m=<hex>&l=<bytes>&c=<chunk>&t=<title>`
+— only `m` is required; `c` is capped at 64; `t` labels the dump header. Every
+parameter has short and long aliases (`m`/`mem`/`memory`, `l`/`len`/`length`,
+`c`/`s`/`chunk`/`size`, `t`/`title`).
+
+Pointer chasing is the point: read a pointer, feed it back as `m`. `CVTPTR` is
+at `0x10`, so `/.dm?m=10&l=16` yields the CVT, and CVT+`0x130` is `CVTTZ`.
+
+**`/.dmtt` — HTTPDMTT, Master Trace Table.** No parameters needed (`?d=1`
+toggles a raw-data variant). This is the console log, so it is where RAKF
+messages, `HTTPDnnn` WTOs and abends actually show up — check it before
+theorising about why a request failed.
+
+**Legacy, superseded by mvsMF** — only touch when working on them: `/dsl/*`
+(HTTPDSL: `help`, `list?hlq=`, `pds?dsn=`, `print?dsn=&member=`) and `/jes/*`
+(HTTPJES2: `help`, `status`, `ddlist`, `print`/`view`, and POST-only `cancel`,
+`purge`, `purgeall`). `/jes/status?jobname=` and `/jes/ddlist` return JSON.
+
+Note for anyone reading `jesst.c`: its output goes through `printf`, and in a
+module `stdout` reaches the HTTP client — so those `printf`s *are* the response
+body, not log output.
+
+**Known display bug:** the `HTTPCGI` field table in `httpdsrv.c` predates the
+per-route auth policy. It shows `login` (legacy) and omits `auth` / `resattr` /
+`resclass` / `resname`, so on an authorization question it can say the opposite
+of the truth — `/zosmf/info` reports `login 0` while answering 401. Read the hex
+at `+14`. Tracked as issue #146.

--- a/credentials/src/credtest.c
+++ b/credentials/src/credtest.c
@@ -10,8 +10,6 @@ int main(int argc, char **argv)
 {
 	int			rc = 0;
 	CREDID		id = credid_init(NULL);
-	CREDTOK		tok = credtok_gen(&id);
-	ACEE		*acee = (ACEE*)0x12345678;
 	CRED		*cred;
 	CRED		***array;
 	unsigned	addr;

--- a/project.toml
+++ b/project.toml
@@ -6,7 +6,24 @@ type = "application"
 [build]
 # -DVERSION feeds httpd.c's `#ifndef VERSION` (otherwise it reports
 # "0.0.0-unknown"). v1's mbt injected it automatically; v2 does not.
-cflags = ["-I", "include", "-I", "credentials/include", '-DVERSION=\"$(PROJECT_VERSION)\"']
+#
+# -Wall -Werror: the root CLAUDE.md has always documented these as enforced,
+# but nothing passed them, so 598 warnings accumulated unseen -- among them a
+# printf with two %s and one argument. Issue #138 cleared the tree; this line
+# is what keeps it clear. Adding a warning now fails the build, which is the
+# point. Do not add -Wno-* here: the trigraph warnings that would have needed
+# one were removed at the source instead (#139).
+cflags = ["-I", "include", "-I", "credentials/include", '-DVERSION=\"$(PROJECT_VERSION)\"',
+          "-Wall", "-Werror"]
+
+[host]
+# `make test-host` reuses build.cflags (mbt/scripts/mbttesthost.py) but compiles
+# with the developer machine's cc, whose -Wall is a different and far larger set
+# than cc370's -- the pointer-sign warnings alone run into the hundreds, and
+# none of them say anything about the MVS build. -Werror exists here to keep the
+# shipped target build clean; gating the fast host loop on another compiler's
+# opinions would only make that loop unusable. Warnings still print.
+cflags = ["-Wno-error"]
 
 [dependencies]
 "mvslovers/ufsd" = "=1.0.0-dev"

--- a/src/cgistart.c
+++ b/src/cgistart.c
@@ -211,7 +211,6 @@ __start(char *p, char *pgmname, int tsojbid, void **pgmr1)
 int
 printf(const char *format, ...)
 {
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;

--- a/src/httpcons.c
+++ b/src/httpcons.c
@@ -386,7 +386,6 @@ d_time(char *buf)
 	int 		minutes 	= buf ? strtol(buf, &next, 10) : 0;
 	time64_t	gmt 		= time64(NULL);
 	time64_t	lot;
-	unsigned    offset;
 	struct tm	tm;
 	char		tbuf[128];
 
@@ -570,7 +569,6 @@ d_thread(char *buf)
     int         rc      = 0;
     CTHDTASK    *task   = cthread_self();
     CTHDMGR     *mgr;
-    CTHDWORK    *work;
     unsigned    count;
     unsigned    n;
 
@@ -634,7 +632,6 @@ s_maxtask(char *buf)
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     int         rc      = 0;
-    CTHDTASK    *task   = cthread_self();
     CTHDMGR     *mgr;
 	char		*next = NULL;
 	unsigned    value = strtoul(buf, &next, 10);
@@ -678,7 +675,6 @@ s_mintask(char *buf)
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     int         rc      = 0;
-    CTHDTASK    *task   = cthread_self();
     CTHDMGR     *mgr;
 	char		*next = NULL;
 	unsigned    value = strtoul(buf, &next, 10);

--- a/src/httpcred.c
+++ b/src/httpcred.c
@@ -6,12 +6,10 @@
 static int process_get(HTTPD *httpd, HTTPC *httpc);
 static int process_post(HTTPD *httpd, HTTPC *httpc);
 
-static int dump_env(HTTPD *httpd, HTTPC *httpc, int hidden);
 
 int httpcred(HTTPC *httpc)
 {
     HTTPD       *httpd  = httpc->httpd;
-    HTTPV		*env;
     char		*method;
 
 	/* get the request method */
@@ -42,32 +40,6 @@ quit:
 	return 0;
 }
 
-static int 
-dump_env(HTTPD *httpd, HTTPC *httpc, int hidden)
-{
-	int		rc = 0;
-	
-	rc = http_printf(httpc, "<pre%s>\n", hidden ? " hidden" : "");
-	if (rc) goto quit;
-
-    if (httpc->env) {
-        unsigned count = array_count(&httpc->env);
-        unsigned n;
-        for(n=0;n<count;n++) {
-			HTTPV *env = httpc->env[n];
-			
-			if (!env) continue;
-
-			rc = http_printf(httpc, "httpc->env[%u] \"%s\"=\"%s\"\n", n, env->name, env->value);
-			if (rc) goto quit;
-        }
-    }
-    
-    rc = http_printf(httpc, "</pre>\n");
-
-quit:
-	return rc;
-}
 
 static const char *head[] = {
 	"<head>",
@@ -231,7 +203,6 @@ print_body(HTTPD *httpd, HTTPC *httpc, const char *msg)
 {
 	int		i;
 	int		rc;
-	char	*p;
 	char	*uri = http_get_env(httpc, "HTTP_Cookie-Sec-Uri");
 	char	esc[512];
 

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -229,7 +229,6 @@ static void
 close_fd_set(void)
 {
     CLIBGRT *grt    = __grtget();
-    int i;
 
     http_enter("close_fd_set()\n");
     if (grt->grtsock) {
@@ -434,12 +433,10 @@ quit:
 static int
 socket_thread(void *arg1, void *arg2)
 {
-	CLIBCRT     *crt    = __crtget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     unsigned    *psa    = (unsigned *)0;
     unsigned    *tcb    = (unsigned *)psa[0x21C/4]; /* A(TCB) from PSATOLD  */
-    unsigned    *ascb   = (unsigned *)psa[0x224/4]; /* A(ASCB) from PSAAOLD */
     CTHDTASK    *task   = cthread_self();
     CTHDMGR     *mgr    = httpd->mgr;
     int         rc;
@@ -640,14 +637,9 @@ serve_client(HTTPC *httpc, CTHDWORK *work)
 static int
 worker_thread(void *udata, CTHDWORK *work)
 {
-    CLIBCRT     *crt    = __crtget();           /* A(CLIBCRT) from TCBUSER  */
-    CLIBGRT     *grt    = __grtget();
-    HTTPD       *httpd  = grt->grtapp1;
     unsigned    *psa    = (unsigned *)0;
     unsigned    *tcb    = (unsigned *)psa[0x21C/4]; /* A(TCB) from PSATOLD  */
-    unsigned    *ascb   = (unsigned *)psa[0x224/4]; /* A(ASCB) from PSAAOLD */
     CTHDTASK    *task   = cthread_self();
-    CTHDMGR     *mgr    = work->mgr;
     int         rc      = 0;
     char        *data   = NULL;
     HTTPC       *httpc  = NULL;
@@ -855,14 +847,12 @@ static int unauth_setup(const char *name)
 int
 main(int argc, char **argv)
 {
-    CLIBPPA     *ppa    = __ppaget();   /* A(CLIBPPA)               */
     CLIBCRT     *crt    = __crtget();   /* A(CLIBCRT)               */
     CLIBGRT     *grt    = __grtget();   /* A(CLIBGRT)               */
     HTTPD       *httpd  = 0;
 #if 0
     unsigned    *psa    = (unsigned *)0;
     unsigned    *tcb    = (unsigned *)psa[0x21C/4]; /* A(TCB) from PSATOLD  */
-    unsigned    *ascb   = (unsigned *)psa[0x224/4]; /* A(ASCB) from PSAAOLD */
     unsigned    *asxb   = (unsigned *)ascb[0x6C/4]; /* A(ASXB) from ASCBASXB*/
     unsigned    *acee   = (unsigned *)asxb[0xC8/4]; /* A(ACEE) from ASXBSENV*/
 #endif
@@ -872,7 +862,6 @@ main(int argc, char **argv)
     int         rc;
     unsigned    count;
     unsigned    *ecblist[10];
-    char        buf[1024];
     HTTPD       server;
 
     /* If this message has a leading '+' then we're not APF authorized yet. */

--- a/src/httpdbug.c
+++ b/src/httpdbug.c
@@ -10,7 +10,6 @@ http_debug(HTTPC *httpc, const char *options)
 	HTTPD 		*httpd 		= httpc->httpd;
 	int			len;
 	char		*opt;
-	char		*next;
 	char		opts[256];
 	
 	if (!options) goto quit;

--- a/src/httpdm.c
+++ b/src/httpdm.c
@@ -21,8 +21,6 @@ static int try_memory(HTTPD *httpd, HTTPC *httpc, OPTIONS *options);
 
 int main(int argc, char **argv)
 {
-    int         rc      = 0;
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;

--- a/src/httpdmtt.c
+++ b/src/httpdmtt.c
@@ -4,13 +4,10 @@
 
 #define httpx   (httpd->httpx)
 
-static int getself(char *jobname, char *jobid);
 static int display_mtt(HTTPD *httpd, HTTPC *httpc, int data);
 
 int main(int argc, char **argv)
 {
-    int         rc      = 0;
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;
@@ -100,29 +97,3 @@ quit:
 	return 0;
 }
 
-static int
-getself(char *jobname, char *jobid)
-{
-    unsigned    *psa        = (unsigned*)0;
-    unsigned    *tcb        = (unsigned*)psa[540/4];    /* A(current TCB) */
-    unsigned    *jscb       = (unsigned*)tcb[180/4];    /* A(JSCB) */
-    unsigned    *ssib       = (unsigned*)jscb[316/4];   /* A(SSIB) */
-
-    const char  *name       = (const char*)tcb[12/4];   /* A(TIOT), but the job name is first 8 chars of TIOT so we cheat just a bit */
-    const char  *id         = ((const char*)ssib) + 12; /* jobid is in SSIB at offset 12 */
-    int         i;
-
-    for(i=0; i < 8 && name[i] > ' '; i++) {
-        jobname[i] = name[i];
-    }
-    jobname[i] = 0;
-
-    for(i=0; i < 8 && id[i] >= ' '; i++) {
-        jobid[i] = id[i];
-        /* the job id may have space(s) which should be '0' */
-        if (jobid[i]==' ') jobid[i] = '0';
-    }
-    jobid[i] = 0;
-
-    return 0;
-}

--- a/src/httpdsl.c
+++ b/src/httpdsl.c
@@ -9,11 +9,7 @@ static int do_print(HTTPDS *ds);
 static int do_print_binary(HTTPDS *ds);
 static int do_print_text(HTTPDS *ds);
 
-static int isdataset(const char *name);
-static int ismember(const char *name);
-static int ispattern(const char *name, const char *pattern);
 static char *strupper(char *buf);
-static int dump_ds(HTTPDS *ds);
 
 int main(int argc, char **argv)
 {
@@ -352,115 +348,8 @@ do_help(HTTPDS *ds)
     return 0;
 }
 
-static int 
-isdataset(const char *name)
-{
-	int		dataset = 0;
-	int		levels  = 0;
-	int		member  = 0;
-	int		len;
-	char	buf[256];
-	char	*p;
 
-	strcpy(buf, name);
-	
-	if (ismember(buf)) {
-		/* looks like a single high level qualifier */
-		if (!isdigit((unsigned char)buf[0])) {
-			dataset = 1;
-			goto quit;
-		}
-	}
 
-	if (strstr(buf, "..")) goto quit;	/* can't have and empty dataset level name */
-	
-	for(p = strtok(buf, "."); p; p = strtok(NULL, ".")) {
-		char *lparen = strchr(p, '(');
-		char *rparen = strrchr(p, ')');
-	
-		// wtof("   %s: p=\"%s\"", __func__, p ? p : "(null)");
-		if (lparen && rparen) {
-			if (member) goto quit;		/* we've already seen a member so die */
-			member++;
-			*lparen = 0;
-			*rparen = 0;
-		}
-
-		levels++;
-		len = strlen(p);
-		
-		if (len < 1) goto quit;			/* dataset level name too short */
-		if (len > 8) goto quit;			/* dataset level name too long */
-		if (isdigit((unsigned char)p[0])) goto quit;	/* dataset level name can not start with a number */
-		if (!ismember(p)) goto quit;	/* bad character in name */
-
-		if (lparen && rparen) {
-			if (strlen(lparen+1) > 8) goto quit;	/* dataset level name too long */
-			if (!ismember(lparen+1)) goto quit;	/* bad character in name */
-
-			*lparen = '(';
-			*rparen = ')';
-		}
-
-	}
-
-	/* name could be a dataset */
-	if (levels <= 22) {
-		int maxlen = 44;
-		
-		if (member > 1) goto quit;	/* only 1 member allowed */
-		
-		if (member) {
-			maxlen += 10;	/* maxlen += strlen("(12345678)") */
-		}
-
-		if (strlen(name) <= maxlen) {
-			dataset = 1;
-		}
-	}
-
-quit:
-	// wtof("   %s(\"%s\") %s", __func__, name, dataset ? "SUCCESS" : "FAILED");
-	return dataset;
-}
-
-static int 
-ismember(const char *name)
-{
-	int		member = 0;
-	int		len = strlen(name);
-	int		i;
-
-	if (len < 1) goto quit;				/* invalid member name */
-
-	if (len <= 8) {
-		member = 1;	/* assume the name is a valid member name */
-		for(i=0; name[i]; i++) {
-			if (name[i]=='@') continue;
-			if (name[i]=='#') continue;
-			if (name[i]=='$') continue;
-			if (isalnum((unsigned char)name[i])) continue;
-
-			/* not a valid character for a member name */
-			member = 0;
-			break;
-		}
-	}
-	
-quit:
-	// wtof("   %s(\"%s\") %s", __func__, name, member ? "SUCCESS" : "FAILED");
-	return member;
-}
-
-static int 
-ispattern(const char *name, const char *pattern)
-{
-	int	rc = __patmat(name, pattern);
-	
-	// wtof("   %s(\"%s\",\"%s\") %s", __func__, name, pattern, rc ? "MATCHED" : "NOMATCH");
-	
-	return rc;
-}
 
 static char *
 strupper(char *buf)
@@ -479,52 +368,4 @@ quit:
 	return buf;
 }
 
-static int 
-dump_ds(HTTPDS *ds)
-{
-    const char *p;
-    
-    wtodumpf(ds, sizeof(HTTPDS), "%s HTTPDS", __func__);
-    wtof("ppa           %p", ds->_ppa);
-    wtof("grt           %p", ds->_grt);
-    wtof("crt           %p", ds->_crt);
-    wtof("httpd         %p", ds->_httpd);
-    wtof("httpc         %p", ds->_httpc);
-    wtof("pgm           %s", ds->pgm);
-    wtof("path          %s", ds->path);
-    wtof("verb          %s", ds->verb);
-    wtof("hlq           %s", ds->hlq);
-    wtof("dsn           %s", ds->dsn);
-    wtof("dstype        %s", ds->dstype);
-    wtof("member        %s", ds->member);
-    wtof("format        %s", ds->format);
-    wtof("binary        %d", ds->binary);
-    wtof("e2a           %d", ds->e2a);
-    switch(ds->type) {
-    default:
-    case TYPE_UNKNOWN:  p = "UNKNOWN";  break;
-    case TYPE_HLQ:      p = "HLQ";      break;
-    case TYPE_DSN:      p = "DSN";      break;
-    case TYPE_DSNMEM:   p = "DSNMEM";   break;
-    }
-        
-    wtof("type          %d %s", ds->type, p);
-
-    switch(ds->org) {
-    default:
-    case ORG_UNKNOWN:   p = "UNKNOWN";  break;
-    case ORG_PS:        p = "PS";       break;
-    case ORG_PDS:       p = "PDS";      break;
-    }
-    wtof("org           %d %s", ds->org, p);
-
-    wtof("start         %f", ds->start);
-    wtof("end           %f", ds->end);
-    if (ds->start > 0.0 && ds->end > 0.0) {
-        double elapsed = ds->end - ds->start;
-        wtof("elapsed       %f", elapsed);
-    }
-
-    return 0;
-}
 

--- a/src/httpdsll.c
+++ b/src/httpdsll.c
@@ -2,16 +2,13 @@
 #include "httpd.h"
 #include "httpds.h"         /* dataset services common */
 
-static int do_list(HTTPDS *ds);
 static int do_list_hlq_json(HTTPDS *ds, DSLIST **dslist);
 static int do_list_hlq_print(HTTPDS *ds, DSLIST **dslist);
 
-static char *strupper(char *buf);
 
 int httpds_list(HTTPDS *ds)
 { 
     int         rc          = 0;
-    FILE    	*fp     	= 0;
     int         len;
     DSLIST      **dslist    = 0;
 

--- a/src/httpdslx.c
+++ b/src/httpdslx.c
@@ -22,7 +22,6 @@ int httpds_xmit(HTTPDS *ds)
 { 
     unsigned    *psa    	= (unsigned *)0;
     void        *ascb   	= (void *)psa[0x224/4];
-    int         rc          = 0;
     int         lockrc      = 8;
 
     http_secs(&ds->start);
@@ -47,8 +46,6 @@ do_xmit(HTTPDS *ds)
 {
     int         rc          = 0;
     FILE        *fp;
-    char        buf[256];
-    char        *p;
 
     // list_xmitout(ds, "do_xmit enter");
 
@@ -255,7 +252,6 @@ link(HTTPDS *ds, const char *pgm)
     int         rc      = -1;   /* link return code     */
     int         prc     = -1;   /* pgm return code      */
     void        *dcb    = NULL; /* no DCB for link      */
-    char 		*query;
     struct {
         unsigned short  len;
         char            buf[512];

--- a/src/httpdsrv.c
+++ b/src/httpdsrv.c
@@ -14,12 +14,7 @@ static int display_file(HTTPD *httpd, HTTPC *httpc);
 static int display_fs(HTTPD *httpd, HTTPC *httpc);
 static int display_mgr(HTTPD *httpd, HTTPC *httpc);
 static int display_task(HTTPD *httpd, HTTPC *httpc);
-static int display_ufsdisks(HTTPD *httpd, HTTPC *httpc);
-static int display_ufsio(HTTPD *httpd, HTTPC *httpc);
-static int display_ufspagers(HTTPD *httpd, HTTPC *httpc);
-static int display_ufssb(HTTPD *httpd, HTTPC *httpc);
 static int display_help(HTTPD *httpd, HTTPC *httpc);
-static int display_ufsvdisks(HTTPD *httpd, HTTPC *httpc);
 static int display_workers(HTTPD *httpd, HTTPC *httpc);
 
 static int display_ufs(HTTPD *httpd, HTTPC *httpc, UFS *ufs);
@@ -44,8 +39,6 @@ static int send_last(HTTPD *httpd, HTTPC *httpc);
 
 int main(int argc, char **argv)
 {
-    int         rc      = 0;
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;
@@ -1360,7 +1353,6 @@ static int
 display_ufs(HTTPD *httpd, HTTPC *httpc, UFS *ufs)
 {
     int         rc      = 0;
-    UCHAR       *u;
 
     if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
@@ -1704,7 +1696,6 @@ display_task(HTTPD *httpd, HTTPC *httpc)
     int         rc      = 0;
     CTHDTASK    *task   = NULL;
     char        *memory = NULL;
-    UCHAR       type;
 
     if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 
@@ -1815,7 +1806,6 @@ display_mgr(HTTPD *httpd, HTTPC *httpc)
     int         rc      = 0;
     CTHDMGR     *mgr    = httpd->mgr;
     char        *s;
-    unsigned    n, count;
 
     if ((rc = send_resp(httpd, httpc, 200) < 0)) goto quit;
 

--- a/src/httpfile.c
+++ b/src/httpfile.c
@@ -38,7 +38,6 @@ int
 http_send_file(HTTPC *httpc, int binary)
 {
     int     rc  = 0;
-    int     rdw = binary ? httpc->rdw : 0;
     int     len = 0;
     int     avail;
 
@@ -266,8 +265,6 @@ quit:
 static int
 ssi_process(HTTPC *httpc, char *ssi)
 {
-    int     rc  		= 0;
-    int     len 		= 0;
     int		newline		= 1;
     char	*p			= NULL;
     char	*next		= NULL;
@@ -414,7 +411,6 @@ quit:
 static int 
 ssi_printenv(HTTPC *httpc)
 {
-    unsigned    indx    = 0;
     HTTPV       *v      = NULL;
     unsigned    count   = array_count(&httpc->env);
     unsigned    n;

--- a/src/httpgetc.c
+++ b/src/httpgetc.c
@@ -2,7 +2,6 @@
 
 int http_getc(HTTPC *httpc)
 {
-    int             rc;
     int             i;
     unsigned char   buf[4];
 

--- a/src/httpjes2.c
+++ b/src/httpjes2.c
@@ -16,7 +16,6 @@ static int getself(char *jobname, char *jobid);
 int main(int argc, char **argv)
 {
     int         rc      = 0;
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;
@@ -126,9 +125,6 @@ do_status(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid, in
     unsigned    count   = 0;
     double      start;
     double      end;
-	__64		diff;
-	__64		div;
-	__64		mod;
     unsigned    n;
     int         i;
     char        jesinfo[20] = "unknown";
@@ -482,7 +478,6 @@ do_print(HTTPD *httpd, HTTPC *httpc, const char *jobname, const char *jobid)
     int         download= 0;
     unsigned    count   = 0;
     unsigned    n;
-    int         i;
     int         rc;
 
     /* we'll send all job output unless one or more dataset id's are specified */
@@ -777,9 +772,7 @@ do_cancel_ex(HTTPD *httpd, HTTPC *httpc, const char *verb, int purge, int all)
     JES         *jes        = NULL;
     char        **jobids    = NULL;
     JESJOB      **jobs      = NULL;
-    JESJOB      *job        = NULL;
     unsigned    jcount      = 0;
-    unsigned    jn          = 0;
     unsigned    count       = 0;
     unsigned    n           = 0;
     char        *buf        = NULL;

--- a/src/httplink.c
+++ b/src/httplink.c
@@ -2,7 +2,6 @@
 
 int httplink(HTTPC *httpc, const char *pgm)
 {
-    void        *ppa    = NULL;
     int         rc      = -1;   /* link return code     */
     int         prc     = -1;   /* pgm return code      */
     void        *dcb    = NULL; /* no DCB for link      */

--- a/src/httppars.c
+++ b/src/httppars.c
@@ -23,10 +23,8 @@ httppars(HTTPC *httpc)
     UCHAR   *buf    = httpc->buf;
     int     len     = CBUFSIZE-1;
     int     pos     = 0;
-    UCHAR   *data   = NULL;
     int     datalen = 0;
     int     nparam  = 0;
-    int     i;
     UCHAR   *p;
     int     salen;
     struct sockaddr sa;

--- a/src/httpprm.c
+++ b/src/httpprm.c
@@ -596,7 +596,6 @@ parse_login(HTTPD *httpd, const char *value)
 {
     char *tmp;
     char *tok;
-    char *saveptr;
 
     tmp = strdup(value);
     if (!tmp) return;

--- a/src/httprepo.c
+++ b/src/httprepo.c
@@ -115,7 +115,6 @@ void
 httpsmf_session(HTTPD *httpd, HTTPC *httpc)
 {
     SMF_HTTPD_SESS rec;
-    double elapsed;
 
     if (!smf_active())
         return;

--- a/src/jespr.c
+++ b/src/jespr.c
@@ -9,7 +9,6 @@ static int prtline(const char *line, unsigned linelen, void *arg);
 
 int main(int argc, char **argv)
 {
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;
@@ -22,8 +21,6 @@ int main(int argc, char **argv)
     unsigned    **dsid  = NULL;
     unsigned    count   = 0;
     unsigned    n;
-    int         i;
-    int         rc;
 
     if (httpd) {
         http_resp(httpc,200);

--- a/src/jesst.c
+++ b/src/jesst.c
@@ -5,11 +5,9 @@
 #define httpx   (httpd->httpx)
 
 static int print_dd(HTTPD *httpd, JESJOB *j, const char *in);
-static int prtline(const char *line, unsigned linelen, void *arg);
 
 int main(int argc, char **argv)
 {
-    CLIBPPA     *ppa    = __ppaget();
     CLIBGRT     *grt    = __grtget();
     HTTPD       *httpd  = grt->grtapp1;
     HTTPC       *httpc  = grt->grtapp2;
@@ -23,8 +21,6 @@ int main(int argc, char **argv)
     double      start   = 0.0;
     double      end     = 0.0;
     unsigned    n;
-    int         i;
-    int         rc;
 #if 0
     struct {
         unsigned short  len;


### PR DESCRIPTION
`/.dsrv`, `/.dm` and `/.dmtt` read live MVS storage over HTTP. Nothing in the repo said they were useful for that — they appeared only as three entries in the built-in CGI list — so they were easy to overlook in favour of reading code and guessing.

Issue #145 got pinned down by chasing `CVTPTR` at `0x10` into `CVTTZ` with `/.dm` and computing the offset from the actual field value, rather than by reasoning about what the timezone probably was. That working pattern is what this documents.

## What is recorded

- The `?target=` surface of `/.dsrv`, which blocks need `&m=` and — the part that was genuinely missing — **where those addresses come from**: `httpcgi` at `+44` of the HTTPD block, `mgr` at `+34`, `socket_thread` at `+30`, `ufssys` at `+54`.
- `/.dm`'s parameters including the short/long aliases and the `c<=64` cap, plus pointer chasing as the intended use.
- `/.dmtt` is the console log, so it is where RAKF messages and `HTTPDnnn` WTOs actually surface — worth checking before theorising about a failed request.
- **None of them is registered unless `DD:HTTPDPRM` says so.** Easy to conclude a module is broken when it was simply never routed.
- `/dsl/*` and `/jes/*` marked as superseded by mvsMF, with their verbs listed, since they are still the quickest JES2 cross-check.
- That `jesst.c`'s `printf` output **is** the HTTP response body in a module context — `stdout` reaches the client. Not obvious from the source and it changes how you read that file.
- A warning that `/.dsrv`'s HTTPCGI field table is a version behind the struct (#146): it shows the legacy `login` and omits `auth`/`res*`, so `/zosmf/info` reads as `login 0` while answering 401. Trust the hex at `+14`.

Corrects one number in passing: the HTTPD control block is 320 bytes (`0x140`), not the 288 (`0x120`) documented under Data Structures. HTTPCGI is 32, not 20.

## Root CLAUDE.md

The short version — when to reach for these rather than guess — went into `/Users/mike/repos/mvs/.workspace/CLAUDE.md` (the ecosystem root, a separate repo, not part of this PR). It is scoped explicitly to httpd and the projects whose deliverable is a module running under it (mvsmf, httprexx, httplua), and says it does not apply to cc370, libc370, ufsd, ftpd or mbt.

It also carries the zsh caution, because that one cost real time on this system: `A="-u u:p"; curl $A …` does not word-split under zsh, so the userid arrives with a leading space and every request 401s while looking exactly like a server fault — it was briefly blamed on a fresh deploy before the trace table showed `USER: IBMUSER~`.

Docs only, no code change.