### PR TITLE
Tell the caller why a server module cannot run standalone

### DIFF
--- a/src/cgistart.c
+++ b/src/cgistart.c
@@ -44,6 +44,53 @@ HTTPX *httpx = 0;
 */
 #define httpx   http_get_httpx(httpd)
 
+/* not_a_server_module() - say why this module cannot run, then end the step.
+**
+** Everything below that a server module needs comes from HTTPD: the server
+** context through the GRT, and the DDs the started task allocates.  Reaching
+** __start() without them means somebody ran the module by itself -- a
+** `CALL 'HTTPD.LINKLIB(HTTPDSL)'` from TSO, or an EXEC PGM= in a batch job.
+** That used to end in a bare __exita(): a silent RC 12 with no message
+** anywhere, so the person who made the mistake was told nothing (issue #141).
+**
+** Reporting it needs an output channel, which is the very thing that may be
+** missing -- so open one.  fopen() on a name starting with '*' goes to
+** libc370's __fpstar(), which allocates the destination dynamically via SVC 99
+** and picks it by environment: the terminal under TSO foreground, a SYSOUT
+** dataset in batch and in TSO background.  Measured in all three (#141).
+**
+** Do NOT branch on GRTFLAG1_TSO to choose a destination.  That flag is derived
+** from the shape of the parameter list a few lines below, not from the
+** environment, and it comes back clear for a parameterless CALL in every one
+** of the three -- including TSO foreground.  Letting __fpstar() decide is both
+** correct and less code.
+*/
+static void
+not_a_server_module(const char *pgmname, const char *missing)
+{
+    FILE    *own    = NULL;         /* a channel we had to open ourselves */
+    FILE    *msg    = stdout;       /* prefer one that already works      */
+
+    if (!msg) {
+        own = fopen("*SYSPRINT", "w");
+        msg = own;
+    }
+
+    if (msg) {
+        fprintf(msg, "%-8.8s is an HTTPD server module and cannot run on its"
+                     " own.\n", pgmname ? pgmname : "This module");
+        fprintf(msg, "Start it through the HTTPD server, which passes the"
+                     " server context and\n");
+        fprintf(msg, "allocates the files it needs.\n");
+        fprintf(msg, "Missing here: %s\n", missing);
+
+        if (own) fclose(own);
+        else     fflush(msg);
+    }
+
+    __exita(EXIT_FAILURE);
+}
+
 /* we want the internal label for __start as "cgistart" for use with dumps */
 __asm__("\n&FUNC    SETC 'cgistart'");
 int
@@ -107,26 +154,22 @@ __start(char *p, char *pgmname, int tsojbid, void **pgmr1)
         progLen = (unsigned int)p[3];
     }
 
+    /* The server context is what a module cannot substitute for, so test it
+       first: without it no set of DDs would make the module work, and the
+       message should name the real problem rather than the first DD to fail. */
+    if (!httpd && !httpc) {
+        not_a_server_module(pgmname, "the HTTPD server context (GRT)");
+    }
+
     stdout = fopen("DD:HTTPDOUT", "w");
-    if (!stdout && !httpc) __exita(EXIT_FAILURE);
+    if (!stdout && !httpc) not_a_server_module(pgmname, "DD:HTTPDOUT");
 
     stderr = fopen("DD:HTTPDERR", "w");
-    if (!stderr && !httpc) {
-        if (stdout) {
-            printf("HTTPDERR DD not defined\n");
-            fclose(stdout);
-        }
-        __exita(EXIT_FAILURE);
-    }
+    if (!stderr && !httpc) not_a_server_module(pgmname, "DD:HTTPDERR");
 
     stdin = fopen("DD:HTTPDIN", "r");
     if (!stdin) stdin = fopen("'NULLFILE'", "r");
-    if (!stdin && !httpc) {
-        if (stderr) fprintf(stderr, "HTTPDIN DD not defined\n");
-        if (stdout) fclose(stdout);
-        if (stderr) fclose(stderr);
-        __exita(EXIT_FAILURE);
-    }
+    if (!stdin && !httpc) not_a_server_module(pgmname, "DD:HTTPDIN");
 
     /* load any environment variables */
     if (loadenv("dd:SYSENV")) {


### PR DESCRIPTION
Fixes #141.

A module invoked outside HTTPD — `CALL 'HTTPD.LINKLIB(HTTPDSL)'` from TSO, or `EXEC PGM=` in a batch job — ended in a bare `__exita()` in `cgistart`: RC 12, no message anywhere. The guard in every module's `main()` that exists to explain exactly this was unreachable, because `cgistart` gave up first over a missing DD.

## What changed

`cgistart` now checks the server context **before** the DDs and routes every failure through one function.

Checking the context first is the part that matters: without it no set of DDs would make the module work, so the message names the real problem instead of whichever DD happened to fail first.

Reporting needs an output channel, which is the very thing that may be missing — so it opens one. `fopen()` on a `'*'`-prefixed name reaches libc370's `__fpstar()`, which allocates the destination via SVC 99 and picks it by environment: the terminal under TSO foreground, a SYSOUT dataset in batch and TSO background. That is the same mechanism libc370's own `__start` uses for every ordinary C program (`@@start.c:67`); `cgistart` requiring `DD:HTTPDOUT` was the anomaly.

**Deliberately no branch on `GRTFLAG1_TSO`.** Probing all three environments showed that flag comes back **clear in every one of them, including TSO foreground**, because it is derived from the shape of the parameter list rather than from the environment — a parameterless `CALL` gives `parmLen == 0`, so the test never fires. Letting `__fpstar()` choose is both correct and less code than branching.

## Verified in all three environments

**TSO foreground** — `CALL 'IBMUSER.HTTPD.V4R0M0D.LINKLIB(HTTPDSL)'` from READY:

```
READY
CALL 'IBMUSER.HTTPD.V4R0M0D.LINKLIB(HTTPDSL)'
 HTTPDSL  is an HTTPD server module and cannot run on its own.
 Start it through the HTTPD server, which passes the server context and
 allocates the files it needs.
 Missing here: the HTTPD server context (GRT)
 READY
```

**Batch** — `EXEC PGM=HTTPDSL` against the staging LINKLIB:

```
IEF142I P141BAT STEP1 - STEP WAS EXECUTED - COND CODE 0012
HTTPDSL  is an HTTPD server module and cannot run on its own.
Start it through the HTTPD server, which passes the server context and
allocates the files it needs.
Missing here: the HTTPD server context (GRT)
```

**TSO background** — covered by the environment probe on #141, which showed `fopen("*SYSPRINT")` succeeds under IKJEFT01 and lands in the job's SYSOUT.

Before this change all three printed nothing at all.

- `make` clean under cc370 `-Wall -Werror`, 6 modules link.
- `make test-host`: 63 assertions pass.

## The server path is untouched

Every check still carries its original `&& !httpc`, so a missing DD **under** HTTPD remains exactly as tolerated as it is today — those `__exita()` calls were only ever reachable outside the server. What modules do in their own `main()` is left alone; the five duplicated guards there are out of scope (and adjacent to #105).

Not yet re-verified on the live server: `/dsl/*` through a restarted STC carrying this build. The changed code is unreachable when `httpc` is set, so the risk is structural rather than empirical, but it is worth one pass once the STC is re-bestückt.

## Not merged with this

The throwaway probe module (`test/mvs/tsttsofg.c`) lives on branch `issue-141-tso-probe`, unmerged — it is what produced the three-environment measurements and the `GRTFLAG1_TSO` finding, and it should be deleted rather than kept.