### PR TITLE
Say what GRTFLAG1_TSO actually records

### DIFF
--- a/src/cgistart.c
+++ b/src/cgistart.c
@@ -145,9 +145,22 @@ __start(char *p, char *pgmname, int tsojbid, void **pgmr1)
         grt->grtapp1 = httpd;
     }
 
-    /* need to know if this is a TSO environment straight away
-       because it determines how the permanent files will be
-       opened */
+    /* GRTFLAG1_TSO records the SHAPE OF THE PARAMETER LIST, not the
+       environment, despite what its name and libc370's clibgrt.h comment
+       suggest.  It says "byte 2 is zero, so bytes 0-3 are a TSO command-style
+       prefix and the parm starts at byte 4" -- which is what the argv[0]
+       parsing further down needs, and all it is used for here.
+
+       It is NOT a usable "am I under TSO" test.  Measured (issue #141) on a
+       parameterless CALL it comes back clear in batch, in TSO background under
+       IKJEFT01, and in TSO foreground alike, because parmLen is then 0 and the
+       condition never fires.  The PPA flags are the environment ones --
+       PPAFLAG_TSOFG for foreground, TSOFG|TSOBG for "TSO at all" (and see
+       libc370 #72 before trusting those either).
+
+       The old comment here claimed this determines how the permanent files are
+       opened.  It does not, and did not: the fopen() calls below never looked
+       at it. */
     parmLen = ((unsigned int)p[0] << 8) | (unsigned int)p[1];
     if ((parmLen > 0) && (p[2] == 0)) {
         grt->grtflag1 |= GRTFLAG1_TSO;

--- a/src/httpstrt.c
+++ b/src/httpstrt.c
@@ -28,9 +28,15 @@ __start(char *p, char *pgmname, int tsojbid, void **pgmr1)
     int         progLen = 0;
     char        parmbuf[310];
 
-    /* need to know if this is a TSO environment straight away
-       because it determines how the permanent files will be
-       opened */
+    /* GRTFLAG1_TSO records the SHAPE OF THE PARAMETER LIST, not the
+       environment -- see the longer note at the same point in cgistart.c.  It
+       means "bytes 0-3 are a TSO command-style prefix, the parm starts at byte
+       4", which is what the argv[0] parsing further down needs and all it is
+       used for.  Measured clear in batch, TSO background and TSO foreground on
+       a parameterless call (issue #141), so it cannot answer "am I under TSO".
+
+       The old comment claimed this determines how the permanent files are
+       opened.  It does not; the fopen() calls below never looked at it. */
     parmLen = ((unsigned int)p[0] << 8) | (unsigned int)p[1];
     if ((parmLen > 0) && (p[2] == 0)) {
         grt->grtflag1 |= GRTFLAG1_TSO;


### PR DESCRIPTION
The comment at both sites that set the flag — `cgistart.c` and `httpstrt.c`, identical text — claimed two things, and both were wrong.

```c
    /* need to know if this is a TSO environment straight away
       because it determines how the permanent files will be
       opened */
    parmLen = ((unsigned int)p[0] << 8) | (unsigned int)p[1];
    if ((parmLen > 0) && (p[2] == 0)) {
        grt->grtflag1 |= GRTFLAG1_TSO;
```

**"a TSO environment"** — it is not an environment test. The flag is derived from the *shape of the parameter list*, and on a parameterless call `parmLen` is 0, so the condition never fires. Measured while settling #141:

| | batch | TSO background (IKJEFT01) | TSO foreground (CALL) |
|---|---|---|---|
| `GRTFLAG1_TSO` | clear | clear | **clear** |

Clear in all three, including the TSO case the name promises. What it actually records is "byte 2 is zero, so bytes 0–3 are a TSO command-style prefix and the parm starts at byte 4" — which is exactly what the `argv[0]` parsing further down needs, and the only thing it is used for. `cgistart.c:197`'s own `/* batch or tso "call" */` on the else branch already said so.

This is not academic: reading the flag as an environment indicator is what produced a wrong design proposal on #141, twice, before it was measured. The comment is what made that reading look safe.

**"determines how the permanent files will be opened"** — it does not, and never did. The `fopen()` calls below it have never looked at the flag.

The new comment says what the flag records, what it is used for, and points at the PPA flags as the environment ones — with a warning that those carry their own trap (mvslovers/libc370#72: `PPAFLAG_TSOBG` is set in foreground as well, and `PPAFLAG_TIN`/`TOUT`/`TERR` are never set at all, so `if (ppaflag & PPAFLAG_TOUT)` always answers no).

## Verification

Comments only. `cc370 -O1 -S` for `cgistart.c` and `httpstrt.c` is byte-identical before and after. `make` clean under `-Wall -Werror`, 6 modules link, `make test-host` 63 assertions pass.