### PR TITLE
Default TZOFFSET to the offset libc370 already resolved

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,7 @@ always reachable so an `AUTH=FORM` challenge can render.
 
 | Keyword | Default | Description |
 |---------|---------|-------------|
-| `TZOFFSET` | +00:00 | UTC offset for the `Date:` response header and SMF record timestamps. Format: `+HH:MM` or `-HH:MM`. |
+| `TZOFFSET` | the system's | UTC offset for the `Date:` response header, SMF record timestamps and `DISPLAY TIME`. Format: `+HH:MM` or `-HH:MM`. Omitted, the server takes the offset libc370 resolved at startup — the `TZ` environment variable if the STC allocates a SYSENV/ENVIRON DD that sets it, otherwise the system's `CVTTZ`. |
 
 ## Debug
 

--- a/src/httpprm.c
+++ b/src/httpprm.c
@@ -16,6 +16,7 @@
 ** those definitions, so a later header will agree rather than conflict. */
 extern int sleep(unsigned seconds);
 extern int __tzset(int tzoffset);
+extern int __tzget(void);       /* src/clib/@@tzget.c -- returns crt->crttzoff */
 
 /* Forward declarations */
 static void set_defaults(HTTPD *httpd);
@@ -138,6 +139,24 @@ set_defaults(HTTPD *httpd)
     httpd->cfg_keepalive_timeout = 5;
     httpd->cfg_keepalive_max     = 100;
     httpd->cfg_session_timeout   = 30;      /* credential idle TTL (min), 0=off */
+
+    /* Inherit the offset libc370 already resolved for this task rather than
+    ** defaulting to 0 (issue #145).  __tzget() returns crt->crttzoff, which
+    ** tzset() filled in from the TZ environment variable, or from the system's
+    ** CVTTZ when TZ is absent -- see httpstrt.c, which calls tzset() right
+    ** after loadenv().
+    **
+    ** Leaving this at 0 made httpd carry a second, disagreeing notion of the
+    ** timezone: 0 here against CVTTZ in every task's CRT, so on any system
+    ** whose CVTTZ is not zero the server's own Date: header, SMF timestamps
+    ** and DISPLAY TIME output were offset from what localtime()/ctime64()
+    ** produced in the same address space -- five hours apart on the reference
+    ** system, with nothing configured.  The 0 was never a chosen default; the
+    ** HTTPD block is static storage and nothing wrote the field.
+    **
+    ** A TZOFFSET statement still wins: http_config() calls set_defaults()
+    ** before it parses, and parse_tzoffset() overwrites this. */
+    httpd->tzoffset         = __tzget();
 }
 
 /* ====================================================================


### PR DESCRIPTION
Part **(a)** of #145. One line plus a comment; part (b) stays open as a policy decision.

## The problem

httpd carried a second, disagreeing notion of the timezone:

| | value on the reference system | set by | consumed by |
|---|---|---|---|
| `httpd->tzoffset` | **0** | nothing, unless the Parmlib has `TZOFFSET` | `Date:` header, SMF timestamps, `DISPLAY TIME` |
| `crt->crttzoff` | **−5 h** | `@@crtset.c` per task from `CVTTZ`; refreshed by the `tzset()` both `__start` paths already call | `localtime()` / `ctime64()` → modules, worker threads, `dbgtime.c` |

Two unrelated defaults for the same question, in one address space. With `SYS2.PARMLIB(HTTPPRM0)` setting **nothing**:

```
0000 11.39.04 TSU   39  F HTTPD,DISPLAY TIME
FFFF 11.39.04 STC  609  HTTPD142I time 2026/08/07 16:39:04 GMT
FFFF 11.39.04 STC  609  HTTPD143I time 2026/08/07 16:39:04 Local TZOFFSET=+0
```

The server calls 16:39 its local time; MVS stamps the same event **11:39**, and so does every module (`/jes/status` renders `start_display` five hours behind `start_stamp`).

The `0` was never a chosen default. The HTTPD block is static storage, `set_defaults()` did not touch the field, and `parse_tzoffset()` — its only writer — runs only for an actual `TZOFFSET` statement. That is also what misled the first analysis on #145: reading an untouched field as "configured for GMT".

## The change

```c
httpd->tzoffset = __tzget();
```

`__tzget()` returns `crt->crttzoff` as `tzset()` left it: the `TZ` environment variable when the STC allocates a SYSENV/ENVIRON DD that sets one, the system's `CVTTZ` otherwise. Both halves then agree with each other and with MVS.

An explicit `TZOFFSET` still wins — `http_config()` calls `set_defaults()` before it parses the member, and `parse_tzoffset()` overwrites the value.

`__tzget()` is declared locally, like `sleep()` and `__tzset()` above it: libc370 ships it (`src/clib/@@tzget.c`) but declares it in no header (mvslovers/libc370#70).

## Documentation

`docs/configuration.md` gave the default as `+00:00`, which documented the bug rather than an intention. It now says the offset comes from the system unless the Parmlib overrides it, and names where the system value comes from.

## Verification

`make` clean under `-Wall -Werror`, 6 modules link, `make test-host` 63 assertions pass.

**No test covers this.** The value comes from the calling task's CRT, so there is nothing a host test can exercise and nothing an MVS test can assert without a known CVTTZ. It has to be checked on the live system:

- `F HTTPD,DISPLAY TIME` — `HTTPD142I` (GMT) and `HTTPD143I` (Local) should now differ by the system offset instead of being equal, and `TZOFFSET=` should report it.
- `/jes/status?jobname=…` — `start_display` should match `start_stamp` interpreted at that same offset.
- Setting `TZOFFSET` in the Parmlib should still override both.

I would rather that ran before this merges, since the whole change is about a value only the live system produces.

## What stays open

Part (b) of #145: an explicit `TZOFFSET` still reaches only the task that parsed the Parmlib, because `parse_tzoffset()` → `__tzset()` writes that task's CRT. Worker threads and modules keep theirs. The libc370-sanctioned way to reach all of them already exists — `TZ` in the SYSENV/ENVIRON DD, honoured by `tzset()` in both `httpstrt.c` and `cgistart.c` — which raises the question whether the Parmlib keyword should do anything beyond feeding httpd's own formatting. That is a decision, not a defect, and it is not in this PR.