### PR TITLE
Retire the TZOFFSET keyword

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,6 @@ CLIENT_TIMEOUT    10
 KEEPALIVE_TIMEOUT 5
 KEEPALIVE_MAX     100
 LOGIN             NONE
-TZOFFSET          +01:00
 DEBUG             0
 CGI    MVSMF      /zosmf/*
 CGI    HTTPDSRV   /.dsrv

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,9 +92,38 @@ always reachable so an `AUTH=FORM` challenge can render.
 
 ## Timezone
 
-| Keyword | Default | Description |
-|---------|---------|-------------|
-| `TZOFFSET` | the system's | UTC offset for the `Date:` response header, SMF record timestamps and `DISPLAY TIME`. Format: `+HH:MM` or `-HH:MM`. Omitted, the server takes the offset libc370 resolved at startup — the `TZ` environment variable if the STC allocates a SYSENV/ENVIRON DD that sets it, otherwise the system's `CVTTZ`. |
+**There is no timezone keyword.** The server takes its offset from the system:
+`tzset()` runs at startup and resolves it from the `TZ` environment variable if
+one is set, otherwise from the system's `CVTTZ`.
+
+To choose a different offset, set `TZ` in the STC's `SYSENV` or `ENVIRON` DD,
+in `[-]HH[:MM[:SS]]` format:
+
+```
+TZ=+02:00
+```
+
+That reaches **every** task — the server, its worker threads and every module —
+because both the server's and the modules' startup code call `tzset()` after
+loading the environment. It is the only supported way to override it.
+
+Timestamps in API responses are unaffected either way: they are returned as
+ISO 8601 instants in UTC (`2026-08-07T17:25:18.000Z`), converted with `gmtime`,
+so the caller localizes them. The `Date:` response header is likewise always
+GMT, as HTTP requires.
+
+> **Retired: `TZOFFSET`.** Up to 4.0.0-dev the Parmlib accepted a `TZOFFSET`
+> keyword. It is now accepted and ignored, with a `HTTPD025W` warning naming the
+> system offset in use, so an existing Parmlib still starts the server — but the
+> statement has no effect and should be deleted.
+>
+> It was removed because it did not do what its name suggested. `TZOFFSET
+> +02:00` reads like a display preference, but it asserted that the machine's
+> TOD clock ran at UTC+2; set on a system at UTC−5 it silently shifted every
+> JES2 timestamp by seven hours. Its documented purposes were never real either
+> — the `Date:` header and the SMF timestamps never read it — and it reached
+> only the one task that parsed the Parmlib, so workers and modules kept the
+> system offset regardless. `TZ` does the job properly. See issue #145.
 
 ## Debug
 
@@ -220,7 +249,6 @@ KEEPALIVE_TIMEOUT=5
 KEEPALIVE_MAX=100
 CLIENT_TIMEOUT=10
 LOGIN=RACF
-TZOFFSET=+01:00
 MOD=MVSMF /zosmf/*
 SMF=AUTH TYPE=243
 ```

--- a/src/httpcons.c
+++ b/src/httpcons.c
@@ -72,7 +72,7 @@ static char *usage[] = {
     "    displays HTTPD client statistics.",
     "Display Threads (D T)",
     "    displays information about the server threads.",
-    "Display TIme [-|+][tzoffset] (D TI)",
+    "Display TIme [-|+][minutes] (D TI)",
     "    displays current time in GMT and local time.",
     "Display Version (D V)",
     "    displays server version.",
@@ -424,7 +424,11 @@ d_time(char *buf)
 
 	gmtime64_r(&lot, &tm);
 	strftime(tbuf, sizeof(tbuf), "HTTPD143I time %Y/%m/%d %H:%M:%S Local", &tm);
-	wtof("%s TZOFFSET=%s%d", tbuf, sign < 0 ? "-" : "+", minutes);
+	/* "OFFSET=" and not "TZOFFSET=": the Parmlib keyword of that name is
+	   retired (#145), and labelling the value after it suggested a setting that
+	   no longer exists.  What is shown is the offset in minutes -- the system's
+	   unless D TI was given one as an argument. */
+	wtof("%s OFFSET=%s%d", tbuf, sign < 0 ? "-" : "+", minutes);
 
 	return 0;
 }

--- a/src/httpprm.c
+++ b/src/httpprm.c
@@ -10,12 +10,12 @@
 #include "httpd.h"
 #include "httpxlat.h"
 
-/* libc370 ships sleep() (src/clib/sleep.c) and __tzset() (src/clib/@@tzset.c)
+/* libc370 ships sleep() (src/clib/sleep.c) and __tzget() (src/clib/@@tzget.c)
 ** but declares neither in any header, so both were implicit declarations here.
-** Declared locally until libc370 exports them; the signatures are copied from
-** those definitions, so a later header will agree rather than conflict. */
+** Declared locally until libc370 exports them (libc370 #70); the signatures are
+** copied from those definitions, so a later header will agree rather than
+** conflict. */
 extern int sleep(unsigned seconds);
-extern int __tzset(int tzoffset);
 extern int __tzget(void);       /* src/clib/@@tzget.c -- returns crt->crttzoff */
 
 /* Forward declarations */
@@ -25,7 +25,7 @@ static void parse_keyvalue(HTTPD *httpd, const char *key, const char *value);
 static void parse_mod(HTTPD *httpd, const char *value);
 static void parse_loc(HTTPD *httpd, const char *value);
 static void parse_login(HTTPD *httpd, const char *value);
-static void parse_tzoffset(HTTPD *httpd, const char *value);
+static void report_tzoffset_retired(HTTPD *httpd);
 static int  do_bind(HTTPD *httpd);
 static void close_stale_port(int port);
 static char *trim(char *s);
@@ -148,14 +148,16 @@ set_defaults(HTTPD *httpd)
     **
     ** Leaving this at 0 made httpd carry a second, disagreeing notion of the
     ** timezone: 0 here against CVTTZ in every task's CRT, so on any system
-    ** whose CVTTZ is not zero the server's own Date: header, SMF timestamps
-    ** and DISPLAY TIME output were offset from what localtime()/ctime64()
-    ** produced in the same address space -- five hours apart on the reference
-    ** system, with nothing configured.  The 0 was never a chosen default; the
-    ** HTTPD block is static storage and nothing wrote the field.
+    ** whose CVTTZ is not zero the server's own DISPLAY TIME output was offset
+    ** from what localtime()/ctime64() produced in the same address space --
+    ** five hours apart on the reference system, with nothing configured.  The
+    ** 0 was never a chosen default; the HTTPD block is static storage and
+    ** nothing wrote the field.
     **
-    ** A TZOFFSET statement still wins: http_config() calls set_defaults()
-    ** before it parses, and parse_tzoffset() overwrites this. */
+    ** This is now the only writer: the TZOFFSET keyword is retired, so nothing
+    ** can override it from the Parmlib.  To choose a different offset, set TZ
+    ** in the STC's SYSENV or ENVIRON DD -- tzset() picks it up in every task,
+    ** and this reads the result.  See report_tzoffset_retired(). */
     httpd->tzoffset         = __tzget();
 }
 
@@ -267,7 +269,9 @@ parse_keyvalue(HTTPD *httpd, const char *key, const char *value)
         parse_login(httpd, value);
     }
     else if (strcmp(key, "TZOFFSET") == 0) {
-        parse_tzoffset(httpd, value);
+        /* Retired (issue #145).  It is accepted and ignored rather than
+           rejected, so an existing Parmlib still starts the server. */
+        report_tzoffset_retired(httpd);
     }
     else if (strcmp(key, "DEBUG") == 0) {
         i = atoi(value);
@@ -644,47 +648,43 @@ parse_login(HTTPD *httpd, const char *value)
 }
 
 /* ====================================================================
-** Parse TZOFFSET value: integer (hours) or +HH:MM format
+** TZOFFSET is retired (issue #145) -- say so and name the replacement.
+**
+** It had exactly one effect left: the default offset for the DISPLAY TIME
+** command, which takes an offset as an argument anyway.  Its two documented
+** purposes were never real -- the Date: header goes through gmtime64()
+** (http1123.c) and the SMF record through localtime() (httprepo.c), neither of
+** which ever read this field -- and the JES2 API stopped reading it in #151.
+**
+** It was also a trap.  "TZOFFSET +02:00" reads like a display preference, but
+** it asserts that the machine's TOD clock runs at UTC+2; set on a system at
+** UTC-5 it silently skewed every JES2 timestamp by seven hours.  And its side
+** effects were misleading: __tzset() reached only the task that parsed the
+** Parmlib, while setenvi("TZOFFSET") published a name nothing reads, since
+** tzset() looks at TZ.
+**
+** The offset now always comes from __tzget() (set_defaults()), i.e. what
+** tzset() resolved for this task from TZ or the system's CVTTZ.  To override it
+** deliberately, set TZ in the STC's SYSENV or ENVIRON DD: both httpstrt.c and
+** cgistart.c call tzset() after loadenv(), so that reaches every task --
+** server, workers and modules -- which is what this keyword never did.
 ** ================================================================= */
 static void
-parse_tzoffset(HTTPD *httpd, const char *value)
+report_tzoffset_retired(HTTPD *httpd)
 {
-    int  sec, hour, min;
-    int  sign;
+    int  sec  = httpd->tzoffset;
+    int  sign = sec < 0 ? -1 : 1;
+    int  hour, min;
 
-    if (!value || !*value) return;
-
-    /* try simple integer (hours offset) first */
-    httpd->tzoffset = atoi(value) * 60;     /* convert minutes to seconds */
-
-    /* try +HH:MM or -HH:MM format */
-    if (strchr(value, ':')) {
-        sign = 1;
-        if (*value == '-') { sign = -1; value++; }
-        else if (*value == '+') value++;
-
-        hour = atoi(value);
-        value = strchr(value, ':');
-        min = value ? atoi(value + 1) : 0;
-
-        httpd->tzoffset = sign * (hour * 3600 + min * 60);
-    } else {
-        httpd->tzoffset = atoi(value) * 60; /* treat as minutes */
-    }
-
-    __tzset(httpd->tzoffset);
-    setenvi("TZOFFSET", httpd->tzoffset, 1);
-
-    /* log it */
-    sec = httpd->tzoffset;
-    sign = sec < 0 ? -1 : 1;
     sec *= sign;
     hour = sec / 3600;
     sec -= hour * 3600;
-    min = sec / 60;
-    sec -= min * 60;
-    wtof("HTTPD025I Time zone offset set to GMT %s%02d:%02d:%02d",
-         sign < 0 ? "-" : "+", hour, min, sec);
+    min  = sec / 60;
+
+    wtof("HTTPD025W TZOFFSET is no longer used; the system offset "
+         "GMT %s%02d:%02d applies", sign < 0 ? "-" : "+", hour, min);
+    wtof("HTTPD025W Set TZ in the SYSENV or ENVIRON DD to override it for "
+         "all tasks");
 }
 
 /* ====================================================================


### PR DESCRIPTION
Closes #145.

## Why it goes

By the time #150 and #151 were done, `TZOFFSET` had **one** effect left: the default offset for `DISPLAY TIME`, a command that takes an offset as an argument anyway.

Both purposes its documentation claimed were never real:

| claimed consumer | what it actually uses |
|---|---|
| `Date:` response header | `gmtime64()` in `http1123.c` — verified against a UTC clock, correct to the second |
| SMF record timestamps | `localtime()` in `httprepo.c` — i.e. the task's CRT offset |

Neither has ever read the field.

What it did have was a failure mode. `TZOFFSET +02:00` reads like a display preference; it actually asserts *the machine's TOD clock runs at UTC+2*. Set on a system at UTC−5 it silently shifted every JES2 timestamp by seven hours, and it took measuring three separate control blocks to pin down. Its side effects pointed the same way — `__tzset()` reached only the task that parsed the Parmlib, so workers and modules kept the system offset, and `setenvi("TZOFFSET")` published a name nothing reads because `tzset()` looks at `TZ`.

The escape hatch it nominally provided — a system whose `CVTTZ` is wrong — **already exists and works better.** `TZ` in the STC's `SYSENV` or `ENVIRON` DD is read by `tzset()`, which both `httpstrt.c` and `cgistart.c` call after `loadenv()`, so it reaches every task instead of one.

## What changes

**The keyword is accepted and ignored**, with a warning naming the offset actually in use and pointing at the replacement:

```
HTTPD025W TZOFFSET is no longer used; the system offset GMT -05:00 applies
HTTPD025W Set TZ in the SYSENV or ENVIRON DD to override it for all tasks
```

Accepted rather than rejected so an existing Parmlib still starts the server.

`httpd->tzoffset` **stays** at offset `0x24`, written only by `set_defaults()` from `__tzget()`. Keeping the field avoids shifting the HTTPD block layout that `/.dsrv` — and anything else reading offsets — depends on.

`DISPLAY TIME` said `TZOFFSET=` for the value it prints, naming a setting that no longer exists. It is `OFFSET=` now, and the help line reads `[minutes]` rather than `[tzoffset]` — the argument is what it always was, only the label was borrowed from the keyword.

## Docs

`docs/configuration.md`'s Timezone section now says where the offset comes from and how to override it with `TZ`, and records the retirement as a note for anyone whose Parmlib still carries the statement. The keyword is out of both sample configurations — that file and `CLAUDE.md`.

## Verification

`make` clean under `-Wall -Werror`, 6 modules link, `make test-host` 63 assertions pass. Deployed to `IBMUSER.HTTPD.V4R0M0D.LINKLIB`.

**Live check worth doing**, and the reference system is set up for it — `SYS2.PARMLIB(HTTPPRM0)` still has `TZOFFSET +02:00`, so a restart on this build should:

1. issue both `HTTPD025W` lines at startup naming `GMT -05:00`;
2. answer `F HTTPD,DISPLAY TIME` with GMT and Local five hours apart and `OFFSET=-300` — where before this build it showed `+120`;
3. leave `/jes/status` timestamps unchanged, since #151 already decoupled them from this field.

Then the statement can come out of the Parmlib, and (1) should stop appearing.