### PR TITLE
Decode the route policy in the debug dump too, and call it MOD

### DIFF
--- a/src/httpdbug.c
+++ b/src/httpdbug.c
@@ -1,8 +1,11 @@
 #include "httpd.h"
 
-static int dump_cgi(HTTPD *httpd, HTTPC *httpc);
+static int dump_route(HTTPD *httpd, HTTPC *httpc);
 static int dump_help(HTTPD *httpd, HTTPC *httpc);
 static int dump_vars(HTTPD *httpd, HTTPC *httpc);
+
+static const char *auth_text(UCHAR auth);
+static const char *attr_text(UCHAR attr);
 
 int 
 http_debug(HTTPC *httpc, const char *options) 
@@ -30,8 +33,8 @@ http_debug(HTTPC *httpc, const char *options)
 
 		len = strlen(opt);
 
-		if (http_cmpn(opt, "cgi", len)==0) {
-			dump_cgi(httpd, httpc);
+		if (http_cmpn(opt, "mod", len)==0) {
+			dump_route(httpd, httpc);
 		}
 		else if (http_cmpn(opt, "help", len)==0 || http_cmp(opt, "?")==0) {
 			dump_help(httpd, httpc);
@@ -50,28 +53,76 @@ quit:
 }
 
 static char *help_text[] = {
-	"cgi      Display server CGI Table.",
+	"mod      Display the server route table (MOD= and LOC= entries).",
 	"help     This help text is displayed.",
 	"vars     Display variables for this request.",
 	NULL
 };
 
-static int 
-dump_cgi(HTTPD *httpd, HTTPC *httpc)
+/* auth_text() / attr_text() - short forms of the per-route auth policy.  The
+** long explanation of Auth=DEFAULT is printed once in the header rather than
+** on every line: this is a one-line-per-route trace, not a field table. */
+static const char *
+auth_text(UCHAR auth)
+{
+	switch (auth) {
+	case HTTP_AUTH_DEFAULT:	return "DEFAULT";
+	case HTTP_AUTH_NONE:	return "NONE";
+	case HTTP_AUTH_FORM:	return "FORM";
+	case HTTP_AUTH_BASIC:	return "BASIC";
+	default:				return "?";
+	}
+}
+
+static const char *
+attr_text(UCHAR attr)
+{
+	switch (attr) {
+	case 0:					return "READ(assumed)";
+	case RACF_ATTR_READ:	return "READ";
+	case RACF_ATTR_UPDATE:	return "UPDATE";
+	case RACF_ATTR_CONTROL:	return "CONTROL";
+	case RACF_ATTR_ALTER:	return "ALTER";
+	default:				return "?";
+	}
+}
+
+static int
+dump_route(HTTPD *httpd, HTTPC *httpc)
 {
     unsigned    count;
     unsigned    n;
 
-	http_printf(httpc, "\nCGI Table\n");
-	
+	http_printf(httpc, "\nRoute Table\n");
+	http_printf(httpc, "   (Auth=DEFAULT means the route carried no AUTH= keyword"
+		" and inherits the global LOGIN policy)\n");
+
     count = array_count(&httpd->httpcgi);
     for (n=0; n < count; n++) {
         HTTPCGI *p = httpd->httpcgi[n];
 
         if (!p) continue;
-        
-        http_printf(httpc, "   Path=\"%s\" Program=\"%s\" Login=%u Wild=%u\n",
-			p->path, p->pgm ? p->pgm : "(none)", p->login, p->wild);
+
+		/* MOD= carries a program, LOC= is a program-less static prefix */
+		http_printf(httpc, "   %s Path=\"%s\"",
+			p->pgm ? "MOD" : "LOC", p->path ? p->path : "(none)");
+
+		if (p->pgm) {
+			http_printf(httpc, " Program=\"%s\"", p->pgm);
+		}
+
+		http_printf(httpc, " Auth=%s Wild=%u", auth_text(p->auth), p->wild);
+
+		/* RES= resource gate -- only routes that carry one */
+		if (p->resclass) {
+			http_printf(httpc, " Res=%s:%s Attr=%s",
+				p->resclass, p->resname ? p->resname : "(none)",
+				attr_text(p->resattr));
+		}
+
+		/* login is the legacy byte, kept visible but named as such -- the
+		   request is gated on Auth above, not on this */
+		http_printf(httpc, " login=%u(legacy)\n", p->login);
     }
 
     return 0;


### PR DESCRIPTION
Fixes #155

Follow-up to #146 / #153, on the second surface: `http_debug()`'s route dump.

## What it printed before

```c
http_printf(httpc, "\nCGI Table\n");
…
http_printf(httpc, "   Path=\"%s\" Program=\"%s\" Login=%u Wild=%u\n",
    p->path, p->pgm ? p->pgm : "(none)", p->login, p->wild);
```

`login` is the legacy byte at `+09`; `auth`, `resattr`, `resclass`, `resname` were not printed at all. Unlike `/.dsrv` there is no hex dump alongside, so for `/zosmf/info` the entire answer was `Login=0` — and that route carries `auth = 1` (`HTTP_AUTH_NONE`), measured live while verifying #153. httpd does not gate it; its 401 comes from mvsMF's own auth track. The old dump could not express that distinction at all.

## What it prints now

```
Route Table
   (Auth=DEFAULT means the route carried no AUTH= keyword and inherits the global LOGIN policy)
   MOD Path="/zosmf/info" Program="MVSMF" Auth=NONE Wild=0 login=0(legacy)
   MOD Path="/zosmf/*" Program="MVSMF" Auth=DEFAULT Wild=1 login=0(legacy)
   LOC Path="/private/*" Auth=BASIC Res=FACILITY:HTTPD.ADMIN Attr=READ Wild=1 login=0(legacy)
```

- `auth` and `resattr` as text, not numbers — same reasoning as the field table: `AUTH=DEFAULT` is not "no authentication" and `resattr` 0 is not "no access". This is a one-line-per-route trace rather than a table, so `DEFAULT` is explained once in the header instead of on every line.
- `Res=`/`Attr=` appear only on routes that carry a `RES=` gate, so the common case stays short and no NULL is dereferenced.
- `MOD` / `LOC` told apart by `pgm != NULL`. The old dump printed `Program="(none)"` and left the reader to infer it.
- `login` keeps its place, marked `(legacy)` — it is still in the block.

## The keyword decision

`?debug=cgi` → `?debug=mod`, **no alias**, consistent with how `target=CGI` was settled in #146: there are no consumers, and this output goes inside an HTML comment. Worth knowing: an unrecognised debug option is a silent no-op in `http_debug()`, so a stale `?debug=cgi` produces an empty `<!-- -->` rather than an error. That was the trade-off in the alternative (keeping `cgi` as an alias), and it was decided against.

Also renamed: heading `CGI Table` → `Route Table`, the help line, and `dump_cgi()` → `dump_route()`.

## Verification

`make` clean under `-Wall -Werror`, all six modules link. **Compile-only** — the rendered output has not been seen, and CI does not execute anything either.

The dump is reached through `QUERY_DEBUG` (`httppc.c:133`) on any request that reaches `CSTATE_DONE`, so the live check after deploy is:

```
curl -s "http://…:8080/.dsrv?target=HTTPD&debug=mod" | tail -20
```

and the route lines should appear in the trailing HTML comment, with `/zosmf/info` reading `Auth=NONE` rather than `Login=0`.
